### PR TITLE
feat: Provide Fantome from both merde-json and merde-json-types

### DIFF
--- a/merde_json/src/lib.rs
+++ b/merde_json/src/lib.rs
@@ -1196,7 +1196,7 @@ macro_rules! impl_trait {
 ///
 /// Note: if you're conditionally deriving `JsonSerialize` and `JsonDeserialize` for a type,
 /// and you don't want the `merde_json` dependency  when it's not used, you can use
-/// `PhantomData<(&'src (), &'val ())>` instead — the derive macros will be happy with that.
+/// `merde_json_types::Fantome` instead — the derive macros will be happy with that.
 ///
 /// This type is really just a convenience so you have less to type.
 #[derive(Default, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]

--- a/merde_json_types/src/lib.rs
+++ b/merde_json_types/src/lib.rs
@@ -3,3 +3,17 @@
 
 #[cfg(feature = "time-types")]
 pub mod time;
+
+/// A type you can use instead of `PhantomData` for convenience.
+///
+/// This type is really just a convenience so you have less to type.
+#[derive(Default, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct Fantome<'src, 'val> {
+    _boo: std::marker::PhantomData<(&'src (), &'val ())>,
+}
+
+impl std::fmt::Debug for Fantome<'_, '_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("Boo!")
+    }
+}


### PR DESCRIPTION
That way, when folks care about making the `merde_json` dependency optional, they can use `merde_json_types`'s Fantome type.