### PR TITLE
Take jiter's parser away from it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,35 +3,10 @@
 version = 3
 
 [[package]]
-name = "ahash"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
-dependencies = [
- "cfg-if",
- "getrandom",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
-
-[[package]]
-name = "bitvec"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
 
 [[package]]
 name = "castaway"
@@ -72,41 +47,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "funty"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
-
-[[package]]
-name = "getrandom"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
-
-[[package]]
-name = "jiter"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e23549143ef50eddffd46ba8cd0229b0a4500aef7518cf2eb0f41c9a09d22b"
-dependencies = [
- "ahash",
- "bitvec",
- "lexical-parse-float",
- "num-bigint",
- "num-traits",
- "smallvec",
-]
 
 [[package]]
 name = "lexical-parse-float"
@@ -139,12 +83,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.155"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
-
-[[package]]
 name = "merde"
 version = "3.1.1"
 dependencies = [
@@ -164,8 +102,10 @@ dependencies = [
 name = "merde_json"
 version = "3.0.1"
 dependencies = [
- "jiter",
+ "lexical-parse-float",
  "merde_core",
+ "num-bigint",
+ "num-traits",
 ]
 
 [[package]]
@@ -212,12 +152,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
-
-[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -240,12 +174,6 @@ checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "radium"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rustversion"
@@ -280,12 +208,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "smallvec"
-version = "1.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
-
-[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -301,12 +223,6 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
-
-[[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "time"
@@ -344,44 +260,3 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
-name = "wyz"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
-dependencies = [
- "tap",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]

--- a/Justfile
+++ b/Justfile
@@ -2,9 +2,9 @@ check:
     #!/bin/bash -eux
     cargo check --example simple --no-default-features --features=json
     cargo run --example simple --features=core,json
-    cargo test -F full
     cargo check --no-default-features
     cargo hack --feature-powerset check
+    cargo test -F full
 
     pushd zerodeps-example
     cargo check

--- a/merde_json/Cargo.toml
+++ b/merde_json/Cargo.toml
@@ -11,9 +11,12 @@ keywords = ["json", "serialization", "deserialization", "jiter"]
 categories = ["encoding", "parser-implementations"]
 
 [dependencies]
-jiter = "0.5.0"
+lexical-parse-float = { version = "0.8.5", features = ["format"] }
 merde_core = { version = "3.0.1", path = "../merde_core" }
+num-bigint = { version = "0.4.6", optional = true }
+num-traits = { version = "0.2.19", optional = true }
 
 [features]
 default = []
-full = []
+full = ["num-bigint"]
+num-bigint = ["dep:num-bigint", "dep:num-traits"]

--- a/merde_json/README.md
+++ b/merde_json/README.md
@@ -7,7 +7,14 @@
 ![The merde logo: a glorious poop floating above a pair of hands](https://github.com/user-attachments/assets/763d60e0-5101-48af-bc72-f96f516a5d0f)
 
 Adds JSON serialization/deserialization support for
-[merde](https://crates.io/crates/merde) through the [jiter](https://crates.io/crates/jiter) crate.
+[merde](https://crates.io/crates/merde).
 
 You would normally add a dependency on [merde](https://crates.io/crates/merde)
 directly, enabling its `json` feature.
+
+## Implementation
+
+The underlying parser (including aarch64 SIMD support, bignum support, etc.) has been
+taken wholesale from the [jiter crate](https://crates.io/crates/jiter) for now.
+
+[An issue has been opened](https://github.com/pydantic/jiter/issues/139) to discuss sharing a core.

--- a/merde_json/src/jiter/errors.rs
+++ b/merde_json/src/jiter/errors.rs
@@ -1,0 +1,305 @@
+/// Enum representing all possible errors in JSON syntax.
+///
+/// Almost all of `JsonErrorType` is copied from [serde_json](https://github.com/serde-rs) so errors match
+/// those expected from `serde_json`.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum JsonErrorType {
+    /// float value was found where an int was expected
+    FloatExpectingInt,
+
+    /// duplicate keys in an object
+    DuplicateKey(String),
+
+    /// happens when getting the `Decimal` type or constructing a decimal fails
+    InternalError(String),
+
+    /// NOTE: all errors from here on are copied from serde_json
+    /// [src/error.rs](https://github.com/serde-rs/json/blob/v1.0.107/src/error.rs#L236)
+    /// with `Io` and `Message` removed
+    ///
+    /// EOF while parsing a list.
+    EofWhileParsingList,
+
+    /// EOF while parsing an object.
+    EofWhileParsingObject,
+
+    /// EOF while parsing a string.
+    EofWhileParsingString,
+
+    /// EOF while parsing a JSON value.
+    EofWhileParsingValue,
+
+    /// Expected this character to be a `':'`.
+    ExpectedColon,
+
+    /// Expected this character to be either a `','` or a `']'`.
+    ExpectedListCommaOrEnd,
+
+    /// Expected this character to be either a `','` or a `'}'`.
+    ExpectedObjectCommaOrEnd,
+
+    /// Expected to parse either a `true`, `false`, or a `null`.
+    ExpectedSomeIdent,
+
+    /// Expected this character to start a JSON value.
+    ExpectedSomeValue,
+
+    /// Invalid hex escape code.
+    InvalidEscape,
+
+    /// Invalid number.
+    InvalidNumber,
+
+    /// Number is bigger than the maximum value of its type.
+    NumberOutOfRange,
+
+    /// Invalid unicode code point.
+    InvalidUnicodeCodePoint,
+
+    /// Control character found while parsing a string.
+    ControlCharacterWhileParsingString,
+
+    /// Object key is not a string.
+    KeyMustBeAString,
+
+    /// Lone leading surrogate in hex escape.
+    LoneLeadingSurrogateInHexEscape,
+
+    /// JSON has a comma after the last value in an array or map.
+    TrailingComma,
+
+    /// JSON has non-whitespace trailing characters after the value.
+    TrailingCharacters,
+
+    /// Unexpected end of hex escape.
+    UnexpectedEndOfHexEscape,
+
+    /// Encountered nesting of JSON maps and arrays more than 128 layers deep.
+    RecursionLimitExceeded,
+}
+
+impl std::fmt::Display for JsonErrorType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Messages for enum members copied from serde_json are unchanged
+        match self {
+            Self::FloatExpectingInt => {
+                f.write_str("float value was found where an int was expected")
+            }
+            Self::DuplicateKey(s) => write!(f, "Detected duplicate key {s:?}"),
+            Self::InternalError(s) => write!(f, "Internal error: {s:?}"),
+            Self::EofWhileParsingList => f.write_str("EOF while parsing a list"),
+            Self::EofWhileParsingObject => f.write_str("EOF while parsing an object"),
+            Self::EofWhileParsingString => f.write_str("EOF while parsing a string"),
+            Self::EofWhileParsingValue => f.write_str("EOF while parsing a value"),
+            Self::ExpectedColon => f.write_str("expected `:`"),
+            Self::ExpectedListCommaOrEnd => f.write_str("expected `,` or `]`"),
+            Self::ExpectedObjectCommaOrEnd => f.write_str("expected `,` or `}`"),
+            Self::ExpectedSomeIdent => f.write_str("expected ident"),
+            Self::ExpectedSomeValue => f.write_str("expected value"),
+            Self::InvalidEscape => f.write_str("invalid escape"),
+            Self::InvalidNumber => f.write_str("invalid number"),
+            Self::NumberOutOfRange => f.write_str("number out of range"),
+            Self::InvalidUnicodeCodePoint => f.write_str("invalid unicode code point"),
+            Self::ControlCharacterWhileParsingString => {
+                f.write_str("control character (\\u0000-\\u001F) found while parsing a string")
+            }
+            Self::KeyMustBeAString => f.write_str("key must be a string"),
+            Self::LoneLeadingSurrogateInHexEscape => {
+                f.write_str("lone leading surrogate in hex escape")
+            }
+            Self::TrailingComma => f.write_str("trailing comma"),
+            Self::TrailingCharacters => f.write_str("trailing characters"),
+            Self::UnexpectedEndOfHexEscape => f.write_str("unexpected end of hex escape"),
+            Self::RecursionLimitExceeded => f.write_str("recursion limit exceeded"),
+        }
+    }
+}
+
+pub type JsonResult<T> = Result<T, JsonError>;
+
+/// Represents an error from parsing JSON
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct JsonError {
+    /// The type of error.
+    pub error_type: JsonErrorType,
+    /// The index in the data where the error occurred.
+    pub index: usize,
+}
+
+impl JsonError {
+    pub(crate) fn new(error_type: JsonErrorType, index: usize) -> Self {
+        Self { error_type, index }
+    }
+
+    pub fn get_position(&self, json_data: &[u8]) -> LinePosition {
+        LinePosition::find(json_data, self.index)
+    }
+
+    pub fn description(&self, json_data: &[u8]) -> String {
+        let position = self.get_position(json_data);
+        format!("{} at {}", self.error_type, position)
+    }
+}
+
+impl std::fmt::Display for JsonError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} at index {}", self.error_type, self.index)
+    }
+}
+
+macro_rules! json_error {
+    ($error_type:ident, $index:expr) => {
+        crate::jiter::errors::JsonError::new(
+            crate::jiter::errors::JsonErrorType::$error_type,
+            $index,
+        )
+    };
+}
+
+pub(crate) use json_error;
+
+macro_rules! json_err {
+    ($error_type:ident, $index:expr) => {
+        Err(crate::jiter::errors::json_error!($error_type, $index))
+    };
+}
+
+use crate::jiter::Jiter;
+pub(crate) use json_err;
+
+/// Enum representing all JSON types.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum JsonType {
+    Null,
+    Bool,
+    Int,
+    Float,
+    String,
+    Array,
+    Object,
+}
+
+impl std::fmt::Display for JsonType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Null => f.write_str("null"),
+            Self::Bool => f.write_str("bool"),
+            Self::Int => f.write_str("int"),
+            Self::Float => f.write_str("float"),
+            Self::String => f.write_str("string"),
+            Self::Array => f.write_str("array"),
+            Self::Object => f.write_str("object"),
+        }
+    }
+}
+
+/// Enum representing either a [JsonErrorType] or a WrongType error.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum JiterErrorType {
+    JsonError(JsonErrorType),
+    WrongType {
+        expected: JsonType,
+        actual: JsonType,
+    },
+}
+
+impl std::fmt::Display for JiterErrorType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::JsonError(error_type) => write!(f, "{error_type}"),
+            Self::WrongType { expected, actual } => {
+                write!(f, "expected {expected} but found {actual}")
+            }
+        }
+    }
+}
+
+/// An error from the Jiter iterator.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct JiterError {
+    pub error_type: JiterErrorType,
+    pub index: usize,
+}
+
+impl std::fmt::Display for JiterError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} at index {}", self.error_type, self.index)
+    }
+}
+
+impl JiterError {
+    pub(crate) fn new(error_type: JiterErrorType, index: usize) -> Self {
+        Self { error_type, index }
+    }
+
+    pub fn get_position(&self, jiter: &Jiter) -> LinePosition {
+        jiter.error_position(self.index)
+    }
+
+    pub fn description(&self, jiter: &Jiter) -> String {
+        let position = self.get_position(jiter);
+        format!("{} at {}", self.error_type, position)
+    }
+
+    pub(crate) fn wrong_type(expected: JsonType, actual: JsonType, index: usize) -> Self {
+        Self::new(JiterErrorType::WrongType { expected, actual }, index)
+    }
+}
+
+impl From<JsonError> for JiterError {
+    fn from(error: JsonError) -> Self {
+        Self {
+            error_type: JiterErrorType::JsonError(error.error_type),
+            index: error.index,
+        }
+    }
+}
+
+/// Represents a line and column in a file or input string, used for both errors and value positions.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LinePosition {
+    /// Line number, starting at 1.
+    pub line: usize,
+    /// Column number, starting at 1.
+    pub column: usize,
+}
+
+impl std::fmt::Display for LinePosition {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "line {} column {}", self.line, self.column)
+    }
+}
+
+impl LinePosition {
+    pub fn new(line: usize, column: usize) -> Self {
+        Self { line, column }
+    }
+
+    /// Find the line and column of a byte index in a string.
+    pub fn find(json_data: &[u8], find: usize) -> Self {
+        let mut line = 1;
+        let mut last_line_start = 0;
+        let mut index = 0;
+        while let Some(next) = json_data.get(index) {
+            if *next == b'\n' {
+                line += 1;
+                last_line_start = index + 1;
+            }
+            if index == find {
+                return Self {
+                    line,
+                    column: index + 1 - last_line_start,
+                };
+            }
+            index += 1;
+        }
+        Self {
+            line,
+            column: index.saturating_sub(last_line_start),
+        }
+    }
+
+    pub fn short(&self) -> String {
+        format!("{}:{}", self.line, self.column)
+    }
+}

--- a/merde_json/src/jiter/jiter.rs
+++ b/merde_json/src/jiter/jiter.rs
@@ -1,0 +1,333 @@
+use crate::jiter::errors::{json_error, JiterError, JsonType, LinePosition};
+use crate::jiter::number_decoder::{NumberAny, NumberFloat, NumberInt, NumberRange};
+use crate::jiter::parse::{Parser, Peek};
+use crate::jiter::string_decoder::{StringDecoder, StringDecoderRange, Tape};
+use crate::jiter::{JsonError, JsonErrorType};
+
+pub type JiterResult<T> = Result<T, JiterError>;
+
+/// A JSON iterator.
+#[derive(Debug)]
+pub struct Jiter<'j> {
+    data: &'j [u8],
+    parser: Parser<'j>,
+    tape: Tape,
+    allow_inf_nan: bool,
+    allow_partial_strings: bool,
+}
+
+impl Clone for Jiter<'_> {
+    /// Clone a `Jiter`. Like the default implementation, but a new empty `tape` is used.
+    fn clone(&self) -> Self {
+        Self {
+            data: self.data,
+            parser: self.parser.clone(),
+            tape: Tape::default(),
+            allow_inf_nan: self.allow_inf_nan,
+            allow_partial_strings: self.allow_partial_strings,
+        }
+    }
+}
+
+impl<'j> Jiter<'j> {
+    /// Constructs a new `Jiter`.
+    ///
+    /// # Arguments
+    /// - `data`: The JSON data to be parsed.
+    /// - `allow_inf_nan`: Whether to allow `NaN`, `Infinity` and `-Infinity` as numbers.
+    pub fn new(data: &'j [u8]) -> Self {
+        Self {
+            data,
+            parser: Parser::new(data),
+            tape: Tape::default(),
+            allow_inf_nan: false,
+            allow_partial_strings: false,
+        }
+    }
+
+    pub fn with_allow_inf_nan(mut self) -> Self {
+        self.allow_inf_nan = true;
+        self
+    }
+
+    pub fn with_allow_partial_strings(mut self) -> Self {
+        self.allow_partial_strings = true;
+        self
+    }
+
+    /// Get the current [LinePosition] of the parser.
+    pub fn current_position(&self) -> LinePosition {
+        self.parser.current_position()
+    }
+
+    /// Get the current index of the parser.
+    pub fn current_index(&self) -> usize {
+        self.parser.index
+    }
+
+    /// Get a slice of the underlying JSON data from `start` to `current_index`.
+    pub fn slice_to_current(&self, start: usize) -> &'j [u8] {
+        &self.data[start..self.current_index()]
+    }
+
+    /// Convert an error index to a [LinePosition].
+    ///
+    /// # Arguments
+    /// - `index`: The index of the error to find the position of.
+    pub fn error_position(&self, index: usize) -> LinePosition {
+        LinePosition::find(self.data, index)
+    }
+
+    /// Peek at the next JSON value without consuming it.
+    pub fn peek(&mut self) -> JiterResult<Peek> {
+        self.parser.peek().map_err(Into::into)
+    }
+
+    /// Assuming the next value is `null`, consume it. Error if it is not `null`, or is invalid JSON.
+    pub fn next_null(&mut self) -> JiterResult<()> {
+        let peek = self.peek()?;
+        match peek {
+            Peek::Null => self.known_null(),
+            _ => Err(self.wrong_type(JsonType::Null, peek)),
+        }
+    }
+
+    /// Knowing the next value is `null`, consume it.
+    pub fn known_null(&mut self) -> JiterResult<()> {
+        self.parser.consume_null()?;
+        Ok(())
+    }
+
+    /// Assuming the next value is `true` or `false`, consume it. Error if it is not a boolean, or is invalid JSON.
+    ///
+    /// # Returns
+    /// The boolean value.
+    pub fn next_bool(&mut self) -> JiterResult<bool> {
+        let peek = self.peek()?;
+        self.known_bool(peek)
+    }
+
+    /// Knowing the next value is `true` or `false`, parse it.
+    pub fn known_bool(&mut self, peek: Peek) -> JiterResult<bool> {
+        match peek {
+            Peek::True => {
+                self.parser.consume_true()?;
+                Ok(true)
+            }
+            Peek::False => {
+                self.parser.consume_false()?;
+                Ok(false)
+            }
+            _ => Err(self.wrong_type(JsonType::Bool, peek)),
+        }
+    }
+
+    /// Assuming the next value is a number, consume it. Error if it is not a number, or is invalid JSON.
+    ///
+    /// # Returns
+    /// A [NumberAny] representing the number.
+    pub fn next_number(&mut self) -> JiterResult<NumberAny> {
+        let peek = self.peek()?;
+        self.known_number(peek)
+    }
+
+    /// Knowing the next value is a number, parse it.
+    pub fn known_number(&mut self, peek: Peek) -> JiterResult<NumberAny> {
+        self.parser
+            .consume_number::<NumberAny>(peek.into_inner(), self.allow_inf_nan)
+            .map_err(|e| self.maybe_number_error(e, JsonType::Int, peek))
+    }
+
+    /// Assuming the next value is an integer, consume it. Error if it is not an integer, or is invalid JSON.
+    pub fn next_int(&mut self) -> JiterResult<NumberInt> {
+        let peek = self.peek()?;
+        self.known_int(peek)
+    }
+
+    /// Knowing the next value is an integer, parse it.
+    pub fn known_int(&mut self, peek: Peek) -> JiterResult<NumberInt> {
+        self.parser
+            .consume_number::<NumberInt>(peek.into_inner(), self.allow_inf_nan)
+            .map_err(|e| {
+                if e.error_type == JsonErrorType::FloatExpectingInt {
+                    JiterError::wrong_type(JsonType::Int, JsonType::Float, self.parser.index)
+                } else {
+                    self.maybe_number_error(e, JsonType::Int, peek)
+                }
+            })
+    }
+
+    /// Assuming the next value is a float, consume it. Error if it is not a float, or is invalid JSON.
+    pub fn next_float(&mut self) -> JiterResult<f64> {
+        let peek = self.peek()?;
+        self.known_float(peek)
+    }
+
+    /// Knowing the next value is a float, parse it.
+    pub fn known_float(&mut self, peek: Peek) -> JiterResult<f64> {
+        self.parser
+            .consume_number::<NumberFloat>(peek.into_inner(), self.allow_inf_nan)
+            .map_err(|e| self.maybe_number_error(e, JsonType::Float, peek))
+    }
+
+    /// Assuming the next value is a number, consume it and return bytes from the original JSON data.
+    pub fn next_number_bytes(&mut self) -> JiterResult<&[u8]> {
+        let peek = self.peek()?;
+        self.known_number_bytes(peek)
+    }
+
+    /// Knowing the next value is a number, parse it and return bytes from the original JSON data.
+    fn known_number_bytes(&mut self, peek: Peek) -> JiterResult<&[u8]> {
+        match self
+            .parser
+            .consume_number::<NumberRange>(peek.into_inner(), self.allow_inf_nan)
+        {
+            Ok(numbe_range) => Ok(&self.data[numbe_range.range]),
+            Err(e) => Err(self.maybe_number_error(e, JsonType::Float, peek)),
+        }
+    }
+
+    /// Assuming the next value is a string, consume it. Error if it is not a string, or is invalid JSON.
+    pub fn next_str(&mut self) -> JiterResult<&str> {
+        let peek = self.peek()?;
+        match peek {
+            Peek::String => self.known_str(),
+            _ => Err(self.wrong_type(JsonType::String, peek)),
+        }
+    }
+
+    /// Knowing the next value is a string, parse it.
+    pub fn known_str(&mut self) -> JiterResult<&str> {
+        match self
+            .parser
+            .consume_string::<StringDecoder>(&mut self.tape, self.allow_partial_strings)
+        {
+            Ok(output) => Ok(output.as_str()),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// Assuming the next value is a string, consume it and return bytes from the original JSON data.
+    pub fn next_bytes(&mut self) -> JiterResult<&[u8]> {
+        let peek = self.peek()?;
+        match peek {
+            Peek::String => self.known_bytes(),
+            _ => Err(self.wrong_type(JsonType::String, peek)),
+        }
+    }
+
+    /// Knowing the next value is a string, parse it and return bytes from the original JSON data.
+    pub fn known_bytes(&mut self) -> JiterResult<&[u8]> {
+        let range = self
+            .parser
+            .consume_string::<StringDecoderRange>(&mut self.tape, self.allow_partial_strings)?;
+        Ok(&self.data[range])
+    }
+
+    /// Assuming the next value is an array, peek at the first value.
+    /// Error if it is not an array, or is invalid JSON.
+    ///
+    /// # Returns
+    /// The `Some(peek)` of the first value in the array is not empty, `None` if it is empty.
+    pub fn next_array(&mut self) -> JiterResult<Option<Peek>> {
+        let peek = self.peek()?;
+        match peek {
+            Peek::Array => self.known_array(),
+            _ => Err(self.wrong_type(JsonType::Array, peek)),
+        }
+    }
+
+    /// Assuming the next value is an array, peat at the first value.
+    pub fn known_array(&mut self) -> JiterResult<Option<Peek>> {
+        self.parser.array_first().map_err(Into::into)
+    }
+
+    /// Peek at the next value in an array.
+    pub fn array_step(&mut self) -> JiterResult<Option<Peek>> {
+        self.parser.array_step().map_err(Into::into)
+    }
+
+    /// Assuming the next value is an object, consume the first key.
+    /// Error if it is not an object, or is invalid JSON.
+    ///
+    /// # Returns
+    /// The `Some(key)` of the first key in the object is not empty, `None` if it is empty.
+    pub fn next_object(&mut self) -> JiterResult<Option<&str>> {
+        let peek = self.peek()?;
+        match peek {
+            Peek::Object => self.known_object(),
+            _ => Err(self.wrong_type(JsonType::Object, peek)),
+        }
+    }
+
+    /// Assuming the next value is an object, conssume the first key and return bytes from the original JSON data.
+    pub fn known_object(&mut self) -> JiterResult<Option<&str>> {
+        let op_str = self.parser.object_first::<StringDecoder>(&mut self.tape)?;
+        Ok(op_str.map(|s| s.as_str()))
+    }
+
+    /// Assuming the next value is an object, peek at the first key.
+    pub fn next_object_bytes(&mut self) -> JiterResult<Option<&[u8]>> {
+        let peek = self.peek()?;
+        match peek {
+            Peek::Object => {
+                let op_range = self
+                    .parser
+                    .object_first::<StringDecoderRange>(&mut self.tape)?;
+                Ok(op_range.map(|r| &self.data[r]))
+            }
+            _ => Err(self.wrong_type(JsonType::Object, peek)),
+        }
+    }
+
+    /// Get the next key in an object, or `None` if there are no more keys.
+    pub fn next_key(&mut self) -> JiterResult<Option<&str>> {
+        let strs = self.parser.object_step::<StringDecoder>(&mut self.tape)?;
+        Ok(strs.map(|s| s.as_str()))
+    }
+
+    /// Get the next key in an object as bytes, or `None` if there are no more keys.
+    pub fn next_key_bytes(&mut self) -> JiterResult<Option<&[u8]>> {
+        let op_range = self
+            .parser
+            .object_step::<StringDecoderRange>(&mut self.tape)?;
+        Ok(op_range.map(|r| &self.data[r]))
+    }
+
+    /// Finish parsing the JSON data. Error if there is more data to be parsed.
+    pub fn finish(&mut self) -> JiterResult<()> {
+        self.parser.finish().map_err(Into::into)
+    }
+
+    fn wrong_type(&self, expected: JsonType, peek: Peek) -> JiterError {
+        match peek {
+            Peek::True | Peek::False => {
+                JiterError::wrong_type(expected, JsonType::Bool, self.parser.index)
+            }
+            Peek::Null => JiterError::wrong_type(expected, JsonType::Null, self.parser.index),
+            Peek::String => JiterError::wrong_type(expected, JsonType::String, self.parser.index),
+            Peek::Array => JiterError::wrong_type(expected, JsonType::Array, self.parser.index),
+            Peek::Object => JiterError::wrong_type(expected, JsonType::Object, self.parser.index),
+            _ if peek.is_num() => self.wrong_num(peek.into_inner(), expected),
+            _ => json_error!(ExpectedSomeValue, self.parser.index).into(),
+        }
+    }
+
+    fn wrong_num(&self, first: u8, expected: JsonType) -> JiterError {
+        let mut parser2 = self.parser.clone();
+        let actual = match parser2.consume_number::<NumberAny>(first, self.allow_inf_nan) {
+            Ok(NumberAny::Int { .. }) => JsonType::Int,
+            Ok(NumberAny::Float { .. }) => JsonType::Float,
+            Err(e) => return e.into(),
+        };
+        JiterError::wrong_type(expected, actual, self.parser.index)
+    }
+
+    fn maybe_number_error(&self, e: JsonError, expected: JsonType, peek: Peek) -> JiterError {
+        if peek.is_num() {
+            e.into()
+        } else {
+            self.wrong_type(expected, peek)
+        }
+    }
+}

--- a/merde_json/src/jiter/mod.rs
+++ b/merde_json/src/jiter/mod.rs
@@ -1,0 +1,16 @@
+//! This contains a stripped-down version of [jiter](https://crates.io/crates/jiter),
+//! containing only their parsers/decoders and not their value types.
+
+mod errors;
+#[allow(clippy::module_inception)]
+mod jiter;
+mod number_decoder;
+mod parse;
+#[cfg(target_arch = "aarch64")]
+mod simd_aarch64;
+mod string_decoder;
+
+pub(crate) use errors::{JiterError, JsonError, JsonErrorType, JsonResult};
+pub(crate) use jiter::Jiter;
+pub(crate) use number_decoder::NumberInt;
+pub(crate) use parse::Peek;

--- a/merde_json/src/jiter/number_decoder.rs
+++ b/merde_json/src/jiter/number_decoder.rs
@@ -1,0 +1,587 @@
+#[cfg(feature = "num-bigint")]
+use num_bigint::BigInt;
+#[cfg(feature = "num-bigint")]
+use num_traits::cast::ToPrimitive;
+
+use std::ops::Range;
+
+use lexical_parse_float::{
+    format as lexical_format, FromLexicalWithOptions, Options as ParseFloatOptions,
+};
+
+use crate::jiter::errors::{json_err, json_error, JsonError, JsonResult};
+
+pub trait AbstractNumberDecoder {
+    type Output;
+
+    fn decode(
+        data: &[u8],
+        index: usize,
+        first: u8,
+        allow_inf_nan: bool,
+    ) -> JsonResult<(Self::Output, usize)>;
+}
+
+/// A number that can be either an [i64] or a [BigInt](num_bigint::BigInt)
+#[derive(Debug, Clone, PartialEq)]
+pub enum NumberInt {
+    Int(i64),
+    #[cfg(feature = "num-bigint")]
+    BigInt(BigInt),
+}
+
+impl From<NumberInt> for f64 {
+    fn from(num: NumberInt) -> Self {
+        match num {
+            NumberInt::Int(int) => int as f64,
+            #[cfg(feature = "num-bigint")]
+            NumberInt::BigInt(big_int) => big_int.to_f64().unwrap_or(f64::NAN),
+        }
+    }
+}
+
+impl TryFrom<&[u8]> for NumberInt {
+    type Error = JsonError;
+
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        let first = *value.first().ok_or_else(|| json_error!(InvalidNumber, 0))?;
+        let (int_parse, index) = IntParse::parse(value, 0, first)?;
+        match int_parse {
+            IntParse::Int(int) => {
+                if index == value.len() {
+                    Ok(int)
+                } else {
+                    json_err!(InvalidNumber, index)
+                }
+            }
+            _ => json_err!(InvalidNumber, index),
+        }
+    }
+}
+
+impl AbstractNumberDecoder for NumberInt {
+    type Output = NumberInt;
+
+    fn decode(
+        data: &[u8],
+        index: usize,
+        first: u8,
+        _allow_inf_nan: bool,
+    ) -> JsonResult<(Self::Output, usize)> {
+        let (int_parse, index) = IntParse::parse(data, index, first)?;
+        match int_parse {
+            IntParse::Int(int) => Ok((int, index)),
+            _ => json_err!(FloatExpectingInt, index),
+        }
+    }
+}
+
+pub struct NumberFloat;
+
+impl AbstractNumberDecoder for NumberFloat {
+    type Output = f64;
+
+    fn decode(
+        data: &[u8],
+        mut index: usize,
+        first: u8,
+        allow_inf_nan: bool,
+    ) -> JsonResult<(Self::Output, usize)> {
+        let start = index;
+
+        let positive = match first {
+            b'N' => return consume_nan(data, index, allow_inf_nan),
+            b'-' => false,
+            _ => true,
+        };
+        if !positive {
+            // we started with a minus sign, so the first digit is at index + 1
+            index += 1;
+        };
+        let first2 = if positive {
+            Some(&first)
+        } else {
+            data.get(index)
+        };
+
+        if let Some(digit) = first2 {
+            if INT_CHAR_MAP[*digit as usize] {
+                const JSON: u128 = lexical_format::JSON;
+                let options = ParseFloatOptions::new();
+                match f64::from_lexical_partial_with_options::<JSON>(&data[start..], &options) {
+                    Ok((float, index)) => Ok((float, index + start)),
+                    Err(_) => {
+                        // it's impossible to work out the right error from LexicalError here, so we parse again
+                        // with NumberRange and use that error
+                        match NumberRange::decode(data, start, first, allow_inf_nan) {
+                            Err(e) => Err(e),
+                            // NumberRange should always raise an error if `parse_partial_with_options`
+                            // except for Infinity and -Infinity, which are handled above
+                            Ok(_) => unreachable!("NumberRange should always return an error"),
+                        }
+                    }
+                }
+            } else if digit == &b'I' {
+                consume_inf_f64(data, index, positive, allow_inf_nan)
+            } else {
+                json_err!(InvalidNumber, index)
+            }
+        } else {
+            json_err!(EofWhileParsingValue, index)
+        }
+    }
+}
+
+/// A number that can be either a [NumberInt] or an [f64]
+#[derive(Debug, Clone, PartialEq)]
+pub enum NumberAny {
+    Int(NumberInt),
+    Float(f64),
+}
+
+impl From<NumberAny> for f64 {
+    fn from(num: NumberAny) -> Self {
+        match num {
+            NumberAny::Int(int) => int.into(),
+            NumberAny::Float(f) => f,
+        }
+    }
+}
+
+impl AbstractNumberDecoder for NumberAny {
+    type Output = NumberAny;
+
+    fn decode(
+        data: &[u8],
+        index: usize,
+        first: u8,
+        allow_inf_nan: bool,
+    ) -> JsonResult<(Self::Output, usize)> {
+        let start = index;
+        let (int_parse, index) = IntParse::parse(data, index, first)?;
+        match int_parse {
+            IntParse::Int(int) => Ok((Self::Int(int), index)),
+            IntParse::Float => NumberFloat::decode(data, start, first, allow_inf_nan)
+                .map(|(f, index)| (Self::Float(f), index)),
+            IntParse::FloatInf(positive) => consume_inf_f64(data, index, positive, allow_inf_nan)
+                .map(|(f, index)| (Self::Float(f), index)),
+            IntParse::FloatNaN => {
+                consume_nan(data, index, allow_inf_nan).map(|(f, index)| (Self::Float(f), index))
+            }
+        }
+    }
+}
+
+fn consume_inf(
+    data: &[u8],
+    index: usize,
+    positive: bool,
+    allow_inf_nan: bool,
+) -> JsonResult<usize> {
+    if allow_inf_nan {
+        crate::jiter::parse::consume_infinity(data, index)
+    } else if positive {
+        json_err!(ExpectedSomeValue, index)
+    } else {
+        json_err!(InvalidNumber, index)
+    }
+}
+
+fn consume_inf_f64(
+    data: &[u8],
+    index: usize,
+    positive: bool,
+    allow_inf_nan: bool,
+) -> JsonResult<(f64, usize)> {
+    let end = consume_inf(data, index, positive, allow_inf_nan)?;
+    if positive {
+        Ok((f64::INFINITY, end))
+    } else {
+        Ok((f64::NEG_INFINITY, end))
+    }
+}
+
+fn consume_nan(data: &[u8], index: usize, allow_inf_nan: bool) -> JsonResult<(f64, usize)> {
+    if allow_inf_nan {
+        let end = crate::jiter::parse::consume_nan(data, index)?;
+        Ok((f64::NAN, end))
+    } else {
+        json_err!(ExpectedSomeValue, index)
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum IntParse {
+    Int(NumberInt),
+    Float,
+    FloatInf(bool),
+    FloatNaN,
+}
+
+impl IntParse {
+    pub(crate) fn parse(data: &[u8], mut index: usize, first: u8) -> JsonResult<(Self, usize)> {
+        let start = index;
+        let positive = match first {
+            b'N' => return Ok((Self::FloatNaN, index)),
+            b'-' => false,
+            _ => true,
+        };
+        if !positive {
+            // we started with a minus sign, so the first digit is at index + 1
+            index += 1;
+        };
+        let first2 = if positive {
+            Some(&first)
+        } else {
+            data.get(index)
+        };
+        let first_value = match first2 {
+            Some(b'0') => {
+                index += 1;
+                return match data.get(index) {
+                    Some(b'.') => Ok((Self::Float, index)),
+                    Some(b'e' | b'E') => Ok((Self::Float, index)),
+                    Some(digit) if digit.is_ascii_digit() => json_err!(InvalidNumber, index),
+                    _ => Ok((Self::Int(NumberInt::Int(0)), index)),
+                };
+            }
+            Some(b'I') => return Ok((Self::FloatInf(positive), index)),
+            Some(digit) if (b'1'..=b'9').contains(digit) => (digit & 0x0f) as u64,
+            Some(_) => return json_err!(InvalidNumber, index),
+            None => return json_err!(EofWhileParsingValue, index),
+        };
+
+        index += 1;
+        let (chunk, new_index) = IntChunk::parse_small(data, index, first_value);
+
+        let ongoing: u64 = match chunk {
+            IntChunk::Ongoing(value) => value,
+            IntChunk::Done(value) => {
+                let mut value_i64 = value as i64;
+                if !positive {
+                    value_i64 = -value_i64;
+                }
+                return Ok((Self::Int(NumberInt::Int(value_i64)), new_index));
+            }
+            IntChunk::Float => return Ok((Self::Float, new_index)),
+        };
+
+        // number is too big for i64, we need to use a BigInt,
+        // or error out if num-bigint is not enabled
+
+        #[cfg(not(feature = "num-bigint"))]
+        {
+            // silence unused variable warning
+            let _ = (ongoing, start);
+            json_err!(NumberOutOfRange, index)
+        }
+
+        #[cfg(feature = "num-bigint")]
+        {
+            #[cfg(target_arch = "aarch64")]
+            // in aarch64 we use a 128 bit registers - 16 bytes
+            const ONGOING_CHUNK_MULTIPLIER: u64 = 10u64.pow(16);
+            #[cfg(not(target_arch = "aarch64"))]
+            // decode_int_chunk_fallback - we parse 18 bytes when the number is ongoing
+            const ONGOING_CHUNK_MULTIPLIER: u64 = 10u64.pow(18);
+
+            const POW_10: [u64; 18] = [
+                10u64.pow(0),
+                10u64.pow(1),
+                10u64.pow(2),
+                10u64.pow(3),
+                10u64.pow(4),
+                10u64.pow(5),
+                10u64.pow(6),
+                10u64.pow(7),
+                10u64.pow(8),
+                10u64.pow(9),
+                10u64.pow(10),
+                10u64.pow(11),
+                10u64.pow(12),
+                10u64.pow(13),
+                10u64.pow(14),
+                10u64.pow(15),
+                10u64.pow(16),
+                10u64.pow(17),
+            ];
+
+            let mut big_value: BigInt = ongoing.into();
+            index = new_index;
+
+            loop {
+                let (chunk, new_index) = IntChunk::parse_big(data, index);
+                if (new_index - start) > 4300 {
+                    return json_err!(NumberOutOfRange, start + 4301);
+                }
+                match chunk {
+                    IntChunk::Ongoing(value) => {
+                        big_value *= ONGOING_CHUNK_MULTIPLIER;
+                        big_value += value;
+                        index = new_index;
+                    }
+                    IntChunk::Done(value) => {
+                        big_value *= POW_10[new_index - index];
+                        big_value += value;
+                        if !positive {
+                            big_value = -big_value;
+                        }
+                        return Ok((Self::Int(NumberInt::BigInt(big_value)), new_index));
+                    }
+                    IntChunk::Float => return Ok((Self::Float, new_index)),
+                }
+            }
+        }
+    }
+}
+
+pub(crate) enum IntChunk {
+    Ongoing(u64),
+    Done(u64),
+    Float,
+}
+
+impl IntChunk {
+    #[inline(always)]
+    fn parse_small(data: &[u8], index: usize, value: u64) -> (Self, usize) {
+        decode_int_chunk_fallback(data, index, value)
+    }
+
+    #[inline(always)]
+    fn parse_big(data: &[u8], index: usize) -> (Self, usize) {
+        // TODO x86_64: use simd
+
+        #[cfg(target_arch = "aarch64")]
+        {
+            crate::jiter::simd_aarch64::decode_int_chunk(data, index)
+        }
+        #[cfg(not(target_arch = "aarch64"))]
+        {
+            decode_int_chunk_fallback(data, index, 0)
+        }
+    }
+}
+
+/// Turns out this is faster than fancy bit manipulation, see
+/// https://github.com/Alexhuszagh/rust-lexical/blob/main/lexical-parse-integer/docs/Algorithm.md
+/// for some context
+#[inline(always)]
+pub(crate) fn decode_int_chunk_fallback(
+    data: &[u8],
+    mut index: usize,
+    mut value: u64,
+) -> (IntChunk, usize) {
+    // i64::MAX = 9223372036854775807 (19 chars) - so 18 chars is always valid as an i64
+    for _ in 0..18 {
+        if let Some(digit) = data.get(index) {
+            if INT_CHAR_MAP[*digit as usize] {
+                // we use wrapping add to avoid branching - we know the value cannot wrap
+                value = value.wrapping_mul(10).wrapping_add((digit & 0x0f) as u64);
+                index += 1;
+                continue;
+            } else if matches!(digit, b'.' | b'e' | b'E') {
+                return (IntChunk::Float, index);
+            }
+        }
+        return (IntChunk::Done(value), index);
+    }
+    (IntChunk::Ongoing(value), index)
+}
+
+pub(crate) static INT_CHAR_MAP: [bool; 256] = {
+    const NU: bool = true;
+    const __: bool = false;
+    [
+        //   1   2   3   4   5   6   7   8   9   A   B   C   D   E   F
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 0
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 1
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 2
+        NU, NU, NU, NU, NU, NU, NU, NU, NU, NU, __, __, __, __, __, __, // 3
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 4
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 5
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 6
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 7
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 8
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 9
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // A
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // B
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // C
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // D
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // E
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // F
+    ]
+};
+
+pub struct NumberRange {
+    pub range: Range<usize>,
+    // in some cfg configurations, this field is never read.
+    #[allow(dead_code)]
+    pub is_int: bool,
+}
+
+impl NumberRange {
+    fn int(data: Range<usize>) -> Self {
+        Self {
+            range: data,
+            is_int: true,
+        }
+    }
+
+    fn float(data: Range<usize>) -> Self {
+        Self {
+            range: data,
+            is_int: false,
+        }
+    }
+}
+
+impl AbstractNumberDecoder for NumberRange {
+    type Output = Self;
+
+    fn decode(
+        data: &[u8],
+        mut index: usize,
+        first: u8,
+        allow_inf_nan: bool,
+    ) -> JsonResult<(Self::Output, usize)> {
+        let start = index;
+
+        let positive = match first {
+            b'N' => {
+                let (_, end) = consume_nan(data, index, allow_inf_nan)?;
+                return Ok((Self::float(start..end), end));
+            }
+            b'-' => false,
+            _ => true,
+        };
+        if !positive {
+            // we started with a minus sign, so the first digit is at index + 1
+            index += 1;
+        };
+
+        match data.get(index) {
+            Some(b'0') => {
+                // numbers start with zero must be floats, next char must be a dot
+                index += 1;
+                return match data.get(index) {
+                    Some(b'.') => {
+                        index += 1;
+                        let end = consume_decimal(data, index)?;
+                        Ok((Self::float(start..end), end))
+                    }
+                    Some(b'e' | b'E') => {
+                        index += 1;
+                        let end = consume_exponential(data, index)?;
+                        Ok((Self::float(start..end), end))
+                    }
+                    Some(digit) if digit.is_ascii_digit() => json_err!(InvalidNumber, index),
+                    _ => return Ok((Self::int(start..index), index)),
+                };
+            }
+            Some(b'I') => {
+                let end = consume_inf(data, index, positive, allow_inf_nan)?;
+                return Ok((Self::float(start..end), end));
+            }
+            Some(digit) if (b'1'..=b'9').contains(digit) => (),
+            Some(_) => return json_err!(InvalidNumber, index),
+            None => return json_err!(EofWhileParsingValue, index),
+        };
+
+        index += 1;
+        for _ in 0..18 {
+            if let Some(digit) = data.get(index) {
+                if INT_CHAR_MAP[*digit as usize] {
+                    index += 1;
+                    continue;
+                } else if matches!(digit, b'.') {
+                    index += 1;
+                    let end = consume_decimal(data, index)?;
+                    return Ok((Self::float(start..end), end));
+                } else if matches!(digit, b'e' | b'E') {
+                    index += 1;
+                    let end = consume_exponential(data, index)?;
+                    return Ok((Self::float(start..end), end));
+                }
+            }
+            return Ok((Self::int(start..index), index));
+        }
+        loop {
+            let (chunk, new_index) = IntChunk::parse_big(data, index);
+            if (new_index - start) > 4300 {
+                return json_err!(NumberOutOfRange, start + 4301);
+            }
+            #[allow(clippy::single_match_else)]
+            match chunk {
+                IntChunk::Ongoing(_) => {
+                    index = new_index;
+                }
+                IntChunk::Done(_) => return Ok((Self::int(start..new_index), new_index)),
+                IntChunk::Float => {
+                    return match data.get(new_index) {
+                        Some(b'.') => {
+                            index = new_index + 1;
+                            let end = consume_decimal(data, index)?;
+                            Ok((Self::float(start..end), end))
+                        }
+                        _ => {
+                            index = new_index + 1;
+                            let end = consume_exponential(data, index)?;
+                            Ok((Self::float(start..end), end))
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn consume_exponential(data: &[u8], mut index: usize) -> JsonResult<usize> {
+    match data.get(index) {
+        Some(b'-' | b'+') => {
+            index += 1;
+        }
+        Some(v) if v.is_ascii_digit() => (),
+        Some(_) => return json_err!(InvalidNumber, index),
+        None => return json_err!(EofWhileParsingValue, index),
+    };
+
+    match data.get(index) {
+        Some(v) if v.is_ascii_digit() => (),
+        Some(_) => return json_err!(InvalidNumber, index),
+        None => return json_err!(EofWhileParsingValue, index),
+    };
+    index += 1;
+
+    while let Some(next) = data.get(index) {
+        match next {
+            b'0'..=b'9' => (),
+            _ => break,
+        }
+        index += 1;
+    }
+
+    Ok(index)
+}
+
+fn consume_decimal(data: &[u8], mut index: usize) -> JsonResult<usize> {
+    match data.get(index) {
+        Some(v) if v.is_ascii_digit() => (),
+        Some(_) => return json_err!(InvalidNumber, index),
+        None => return json_err!(EofWhileParsingValue, index),
+    };
+    index += 1;
+
+    while let Some(next) = data.get(index) {
+        match next {
+            b'0'..=b'9' => (),
+            b'e' | b'E' => {
+                index += 1;
+                return consume_exponential(data, index);
+            }
+            _ => break,
+        }
+        index += 1;
+    }
+
+    Ok(index)
+}

--- a/merde_json/src/jiter/parse.rs
+++ b/merde_json/src/jiter/parse.rs
@@ -1,0 +1,300 @@
+use std::fmt;
+use std::ops::Range;
+
+use crate::jiter::errors::{json_err, JsonResult, LinePosition};
+use crate::jiter::number_decoder::AbstractNumberDecoder;
+use crate::jiter::string_decoder::{AbstractStringDecoder, Tape};
+
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub struct Peek(u8);
+
+#[allow(non_upper_case_globals)] // while testing
+impl Peek {
+    pub const Null: Self = Self(b'n');
+    pub const True: Self = Self(b't');
+    pub const False: Self = Self(b'f');
+    pub const Minus: Self = Self(b'-');
+    pub const Infinity: Self = Self(b'I');
+    pub const NaN: Self = Self(b'N');
+    pub const String: Self = Self(b'"');
+    pub const Array: Self = Self(b'[');
+    pub const Object: Self = Self(b'{');
+}
+
+impl fmt::Debug for Peek {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.0 {
+            b'n' => write!(f, "Null"),
+            b't' => write!(f, "True"),
+            b'f' => write!(f, "False"),
+            b'-' => write!(f, "Minus"),
+            b'I' => write!(f, "Infinity"),
+            b'N' => write!(f, "NaN"),
+            b'"' => write!(f, "String"),
+            b'[' => write!(f, "Array"),
+            b'{' => write!(f, "Object"),
+            _ => write!(f, "Peek({:?})", self.0 as char),
+        }
+    }
+}
+
+impl Peek {
+    pub const fn new(next: u8) -> Self {
+        Self(next)
+    }
+
+    pub const fn is_num(self) -> bool {
+        self.0.is_ascii_digit() || matches!(self, Self::Minus | Self::Infinity | Self::NaN)
+    }
+
+    pub const fn into_inner(self) -> u8 {
+        self.0
+    }
+}
+
+static TRUE_REST: [u8; 3] = [b'r', b'u', b'e'];
+static FALSE_REST: [u8; 4] = [b'a', b'l', b's', b'e'];
+static NULL_REST: [u8; 3] = [b'u', b'l', b'l'];
+static NAN_REST: [u8; 2] = [b'a', b'N'];
+static INFINITY_REST: [u8; 7] = [b'n', b'f', b'i', b'n', b'i', b't', b'y'];
+
+#[derive(Debug, Clone)]
+pub(crate) struct Parser<'j> {
+    data: &'j [u8],
+    pub index: usize,
+}
+
+impl<'j> Parser<'j> {
+    pub fn new(data: &'j [u8]) -> Self {
+        Self { data, index: 0 }
+    }
+
+    #[allow(dead_code)]
+    pub fn slice(&self, range: Range<usize>) -> Option<&[u8]> {
+        self.data.get(range)
+    }
+
+    pub fn current_position(&self) -> LinePosition {
+        LinePosition::find(self.data, self.index)
+    }
+
+    pub fn peek(&mut self) -> JsonResult<Peek> {
+        if let Some(next) = self.eat_whitespace() {
+            Ok(Peek::new(next))
+        } else {
+            json_err!(EofWhileParsingValue, self.index)
+        }
+    }
+
+    pub fn array_first(&mut self) -> JsonResult<Option<Peek>> {
+        self.index += 1;
+        if let Some(next) = self.eat_whitespace() {
+            if next == b']' {
+                self.index += 1;
+                Ok(None)
+            } else {
+                Ok(Some(Peek::new(next)))
+            }
+        } else {
+            json_err!(EofWhileParsingList, self.index)
+        }
+    }
+
+    pub fn array_step(&mut self) -> JsonResult<Option<Peek>> {
+        if let Some(next) = self.eat_whitespace() {
+            match next {
+                b',' => {
+                    self.index += 1;
+                    let next = self.array_peek()?;
+                    if next.is_none() {
+                        json_err!(TrailingComma, self.index)
+                    } else {
+                        Ok(next)
+                    }
+                }
+                b']' => {
+                    self.index += 1;
+                    Ok(None)
+                }
+                _ => {
+                    json_err!(ExpectedListCommaOrEnd, self.index)
+                }
+            }
+        } else {
+            json_err!(EofWhileParsingList, self.index)
+        }
+    }
+
+    pub fn object_first<'t, D: AbstractStringDecoder<'t, 'j>>(
+        &mut self,
+        tape: &'t mut Tape,
+    ) -> JsonResult<Option<D::Output>>
+    where
+        'j: 't,
+    {
+        self.index += 1;
+        if let Some(next) = self.eat_whitespace() {
+            match next {
+                b'"' => self.object_key::<D>(tape).map(Some),
+                b'}' => {
+                    self.index += 1;
+                    Ok(None)
+                }
+                _ => json_err!(KeyMustBeAString, self.index),
+            }
+        } else {
+            json_err!(EofWhileParsingObject, self.index)
+        }
+    }
+
+    pub fn object_step<'t, D: AbstractStringDecoder<'t, 'j>>(
+        &mut self,
+        tape: &'t mut Tape,
+    ) -> JsonResult<Option<D::Output>>
+    where
+        'j: 't,
+    {
+        if let Some(next) = self.eat_whitespace() {
+            match next {
+                b',' => {
+                    self.index += 1;
+                    match self.eat_whitespace() {
+                        Some(b'"') => self.object_key::<D>(tape).map(Some),
+                        Some(b'}') => json_err!(TrailingComma, self.index),
+                        Some(_) => json_err!(KeyMustBeAString, self.index),
+                        None => json_err!(EofWhileParsingValue, self.index),
+                    }
+                }
+                b'}' => {
+                    self.index += 1;
+                    Ok(None)
+                }
+                _ => json_err!(ExpectedObjectCommaOrEnd, self.index),
+            }
+        } else {
+            json_err!(EofWhileParsingObject, self.index)
+        }
+    }
+
+    pub fn finish(&mut self) -> JsonResult<()> {
+        if self.eat_whitespace().is_none() {
+            Ok(())
+        } else {
+            json_err!(TrailingCharacters, self.index)
+        }
+    }
+
+    pub fn consume_true(&mut self) -> JsonResult<()> {
+        self.consume_ident(TRUE_REST)
+    }
+
+    pub fn consume_false(&mut self) -> JsonResult<()> {
+        self.consume_ident(FALSE_REST)
+    }
+
+    pub fn consume_null(&mut self) -> JsonResult<()> {
+        self.consume_ident(NULL_REST)
+    }
+
+    pub fn consume_string<'t, D: AbstractStringDecoder<'t, 'j>>(
+        &mut self,
+        tape: &'t mut Tape,
+        allow_partial: bool,
+    ) -> JsonResult<D::Output>
+    where
+        'j: 't,
+    {
+        let (output, index) = D::decode(self.data, self.index, tape, allow_partial)?;
+        self.index = index;
+        Ok(output)
+    }
+
+    pub fn consume_number<D: AbstractNumberDecoder>(
+        &mut self,
+        first: u8,
+        allow_inf_nan: bool,
+    ) -> JsonResult<D::Output> {
+        let (output, index) = D::decode(self.data, self.index, first, allow_inf_nan)?;
+        self.index = index;
+        Ok(output)
+    }
+
+    /// private method to get an object key, then consume the colon which should follow
+    fn object_key<'t, D: AbstractStringDecoder<'t, 'j>>(
+        &mut self,
+        tape: &'t mut Tape,
+    ) -> JsonResult<D::Output>
+    where
+        'j: 't,
+    {
+        let (output, index) = D::decode(self.data, self.index, tape, false)?;
+        self.index = index;
+        if let Some(next) = self.eat_whitespace() {
+            if next == b':' {
+                self.index += 1;
+                Ok(output)
+            } else {
+                json_err!(ExpectedColon, self.index)
+            }
+        } else {
+            json_err!(EofWhileParsingObject, self.index)
+        }
+    }
+
+    fn consume_ident<const SIZE: usize>(&mut self, expected: [u8; SIZE]) -> JsonResult<()> {
+        self.index = consume_ident(self.data, self.index, expected)?;
+        Ok(())
+    }
+
+    fn array_peek(&mut self) -> JsonResult<Option<Peek>> {
+        if let Some(next) = self.eat_whitespace() {
+            match next {
+                b']' => Ok(None),
+                _ => Ok(Some(Peek::new(next))),
+            }
+        } else {
+            json_err!(EofWhileParsingValue, self.index)
+        }
+    }
+
+    fn eat_whitespace(&mut self) -> Option<u8> {
+        while let Some(next) = self.data.get(self.index) {
+            match next {
+                b' ' | b'\r' | b'\t' | b'\n' => self.index += 1,
+                _ => return Some(*next),
+            }
+        }
+        None
+    }
+}
+
+pub(crate) fn consume_infinity(data: &[u8], index: usize) -> JsonResult<usize> {
+    consume_ident(data, index, INFINITY_REST)
+}
+
+pub(crate) fn consume_nan(data: &[u8], index: usize) -> JsonResult<usize> {
+    consume_ident(data, index, NAN_REST)
+}
+
+fn consume_ident<const SIZE: usize>(
+    data: &[u8],
+    mut index: usize,
+    expected: [u8; SIZE],
+) -> JsonResult<usize> {
+    match data.get(index + 1..=index + SIZE) {
+        Some(s) if s == expected => Ok(index + SIZE + 1),
+        // TODO very sadly iterating over expected cause extra branches in the generated assembly
+        //   and is significantly slower than just returning an error
+        _ => {
+            index += 1;
+            for c in &expected {
+                match data.get(index) {
+                    Some(v) if v == c => index += 1,
+                    Some(_) => return json_err!(ExpectedSomeIdent, index),
+                    _ => break,
+                }
+            }
+            json_err!(EofWhileParsingValue, index)
+        }
+    }
+}

--- a/merde_json/src/jiter/simd_aarch64.rs
+++ b/merde_json/src/jiter/simd_aarch64.rs
@@ -1,0 +1,262 @@
+use std::mem::transmute;
+#[rustfmt::skip]
+use std::arch::aarch64::{
+    uint8x16_t,
+    uint16x8_t,
+    uint32x4_t,
+    uint64x2_t,
+    uint8x8_t,
+    uint16x4_t,
+    uint32x2_t,
+    uint64x1_t,
+    // 16 byte methods
+    vld1q_u8 as simd_load_16,
+    vcgtq_u8 as simd_gt_16,
+    vcltq_u8 as simd_lt_16,
+    vorrq_u8 as simd_or_16,
+    vceqq_u8 as simd_eq_16,
+    vextq_u8 as combine_vecs_16,
+    vsubq_u8 as simd_sub_16,
+    vmulq_u8 as simd_mul_16,
+    vpaddlq_u8 as simd_add_16,
+    vmulq_u16 as simd_mul_u16_8,
+    vpaddlq_u16 as simd_add_u16_8,
+    vmulq_u32 as simd_mul_u32_4,
+    vpaddlq_u32 as simd_add_u32_4,
+    // 8 byte methods
+    vget_low_u8 as simd_get_low,
+    vext_u8 as combine_vecs_8,
+    vsub_u8 as simd_sub_8,
+    vmul_u8 as simd_mul_8,
+    vpaddl_u8 as simd_add_8,
+    vmul_u16 as simd_mul_u16_4,
+    vpaddl_u16 as simd_add_u16_4,
+    vmul_u32 as simd_mul_u32_2,
+    vpaddl_u32 as simd_add_u32_2,
+};
+use crate::jiter::JsonResult;
+
+use crate::jiter::number_decoder::{decode_int_chunk_fallback, IntChunk};
+use crate::jiter::string_decoder::StringChunk;
+
+type SimdVecu8_16 = uint8x16_t;
+type SimdVecu16_8 = uint16x8_t;
+type SimdVecu32_4 = uint32x4_t;
+type SimdVecu64_2 = uint64x2_t;
+
+type SimdVecu8_8 = uint8x8_t;
+type SimdVecu16_4 = uint16x4_t;
+type SimdVecu32_2 = uint32x2_t;
+type SimdVecu64_1 = uint64x1_t;
+const SIMD_STEP: usize = 16;
+
+macro_rules! simd_const {
+    ($array:expr) => {
+        unsafe { transmute($array) }
+    };
+}
+
+const ZERO_DIGIT_U8_8: SimdVecu8_8 = simd_const!([b'0'; 8]);
+const ZERO_VAL_U8_8: SimdVecu8_8 = simd_const!([0u8; 8]);
+const ALT_MUL_U8_8: SimdVecu8_8 = simd_const!([10u8, 1u8, 10u8, 1u8, 10u8, 1u8, 10u8, 1u8]);
+const ALT_MUL_U16_4: SimdVecu16_4 = simd_const!([100u16, 1u16, 100u16, 1u16]);
+const ALT_MUL_U32_2: SimdVecu32_2 = simd_const!([10000u32, 1u32]);
+const ZERO_DIGIT_16: SimdVecu8_16 = simd_const!([b'0'; 16]);
+const NINE_DIGIT_16: SimdVecu8_16 = simd_const!([b'9'; 16]);
+
+const ZERO_VAL_U8_16: SimdVecu8_16 = simd_const!([0u8; 16]);
+const ALT_MUL_U8_16: SimdVecu8_16 = simd_const!([
+    10u8, 1u8, 10u8, 1u8, 10u8, 1u8, 10u8, 1u8, 10u8, 1u8, 10u8, 1u8, 10u8, 1u8, 10u8, 1u8
+]);
+const ALT_MUL_U16_8: SimdVecu16_8 =
+    simd_const!([100u16, 1u16, 100u16, 1u16, 100u16, 1u16, 100u16, 1u16]);
+const ALT_MUL_U32_4: SimdVecu32_4 = simd_const!([10000u32, 1u32, 10000u32, 1u32]);
+
+#[inline(always)]
+pub(crate) fn decode_int_chunk(data: &[u8], index: usize) -> (IntChunk, usize) {
+    if let Some(byte_chunk) = data.get(index..index + SIMD_STEP) {
+        let byte_vec = load_slice(byte_chunk);
+
+        let digit_mask = get_digit_mask(byte_vec);
+        if is_zero(digit_mask) {
+            // all lanes are digits, parse the full vector
+            let value = unsafe { full_calc(byte_vec, 16) };
+            (IntChunk::Ongoing(value), index + SIMD_STEP)
+        } else {
+            // some lanes are not digits, transmute to a pair of u64 and find the first non-digit
+            let last_digit = find_end(digit_mask);
+            let index = index + last_digit as usize;
+            if next_is_float(data, index) {
+                (IntChunk::Float, index)
+            } else if last_digit <= 8 {
+                // none-digit in the first 8 bytes
+                let value = unsafe { first_half_calc(byte_vec, last_digit) };
+                (IntChunk::Done(value), index)
+            } else {
+                // none-digit in the last 8 bytes
+                let value = unsafe { full_calc(byte_vec, last_digit) };
+                (IntChunk::Done(value), index)
+            }
+        }
+    } else {
+        // we got near the end of the string, fall back to the slow path
+        decode_int_chunk_fallback(data, index, 0)
+    }
+}
+
+#[rustfmt::skip]
+fn get_digit_mask(byte_vec: SimdVecu8_16) -> SimdVecu8_16 {
+    unsafe {
+        simd_or_16(
+            simd_lt_16(byte_vec, ZERO_DIGIT_16),
+            simd_gt_16(byte_vec, NINE_DIGIT_16),
+        )
+    }
+}
+
+unsafe fn first_half_calc(byte_vec: SimdVecu8_16, last_digit: u32) -> u64 {
+    let small_byte_vec = simd_get_low(byte_vec);
+    // subtract ascii '0' from every byte to get the digit values
+    let digits: SimdVecu8_8 = simd_sub_8(small_byte_vec, ZERO_DIGIT_U8_8);
+    let digits = match last_digit {
+        0 => return 0,
+        1 => {
+            let t: [u8; 8] = transmute(digits);
+            return t[0] as u64;
+        }
+        2 => combine_vecs_8::<2>(ZERO_VAL_U8_8, digits),
+        3 => combine_vecs_8::<3>(ZERO_VAL_U8_8, digits),
+        4 => combine_vecs_8::<4>(ZERO_VAL_U8_8, digits),
+        5 => combine_vecs_8::<5>(ZERO_VAL_U8_8, digits),
+        6 => combine_vecs_8::<6>(ZERO_VAL_U8_8, digits),
+        7 => combine_vecs_8::<7>(ZERO_VAL_U8_8, digits),
+        8 => digits,
+        _ => unreachable!("last_digit should be less than 8"),
+    };
+    // multiple every other digit by 10
+    let x: SimdVecu8_8 = simd_mul_8(digits, ALT_MUL_U8_8);
+    // add the value together and combine the 8x8-bit lanes into 4x16-bit lanes
+    let x: SimdVecu16_4 = simd_add_8(x);
+    // multiple every other digit by 100
+    let x: SimdVecu16_4 = simd_mul_u16_4(x, ALT_MUL_U16_4);
+    // add the value together and combine the 4x16-bit lanes into 2x32-bit lanes
+    let x: SimdVecu32_2 = simd_add_u16_4(x);
+    // multiple the first value 10000
+    let x: SimdVecu32_2 = simd_mul_u32_2(x, ALT_MUL_U32_2);
+    // add the value together and combine the 2x32-bit lanes into 1x64-bit lane
+    let x: SimdVecu64_1 = simd_add_u32_2(x);
+    // transmute the 64-bit lane into a u64
+    transmute(x)
+}
+
+unsafe fn full_calc(byte_vec: SimdVecu8_16, last_digit: u32) -> u64 {
+    // subtract ascii '0' from every byte to get the digit values
+    let digits: SimdVecu8_16 = simd_sub_16(byte_vec, ZERO_DIGIT_16);
+    let digits = match last_digit {
+        9 => combine_vecs_16::<9>(ZERO_VAL_U8_16, digits),
+        10 => combine_vecs_16::<10>(ZERO_VAL_U8_16, digits),
+        11 => combine_vecs_16::<11>(ZERO_VAL_U8_16, digits),
+        12 => combine_vecs_16::<12>(ZERO_VAL_U8_16, digits),
+        13 => combine_vecs_16::<13>(ZERO_VAL_U8_16, digits),
+        14 => combine_vecs_16::<14>(ZERO_VAL_U8_16, digits),
+        15 => combine_vecs_16::<15>(ZERO_VAL_U8_16, digits),
+        16 => digits,
+        _ => unreachable!("last_digit should be between 9 and 16"),
+    };
+    // multiple every other digit by 10
+    let x: SimdVecu8_16 = simd_mul_16(digits, ALT_MUL_U8_16);
+    // add the value together and combine the 16x8-bit lanes into 8x16-bit lanes
+    let x: SimdVecu16_8 = simd_add_16(x);
+    // multiple every other digit by 100
+    let x: SimdVecu16_8 = simd_mul_u16_8(x, ALT_MUL_U16_8);
+    // add the value together and combine the 8x16-bit lanes into 4x32-bit lanes
+    let x: SimdVecu32_4 = simd_add_u16_8(x);
+    // multiple every other digit by 10000
+    let x: SimdVecu32_4 = simd_mul_u32_4(x, ALT_MUL_U32_4);
+    // add the value together and combine the 4x32-bit lanes into 2x64-bit lane
+    let x: SimdVecu64_2 = simd_add_u32_4(x);
+
+    // transmute the 2x64-bit lane into an array;
+    let t: [u64; 2] = transmute(x);
+    // since the data started out as digits, it's safe to assume the result fits in a u64
+    t[0].wrapping_mul(100_000_000).wrapping_add(t[1])
+}
+
+fn next_is_float(data: &[u8], index: usize) -> bool {
+    let next = unsafe { data.get_unchecked(index) };
+    matches!(next, b'.' | b'e' | b'E')
+}
+
+const QUOTE_16: SimdVecu8_16 = simd_const!([b'"'; 16]);
+const BACKSLASH_16: SimdVecu8_16 = simd_const!([b'\\'; 16]);
+// values below 32 are control characters
+const CONTROL_16: SimdVecu8_16 = simd_const!([32u8; 16]);
+const ASCII_MAX_16: SimdVecu8_16 = simd_const!([127u8; 16]);
+
+#[inline(always)]
+pub(crate) fn decode_string_chunk(
+    data: &[u8],
+    mut index: usize,
+    mut ascii_only: bool,
+    allow_partial: bool,
+) -> JsonResult<(StringChunk, bool, usize)> {
+    while let Some(byte_chunk) = data.get(index..index + SIMD_STEP) {
+        let byte_vec = load_slice(byte_chunk);
+
+        let ascii_mask = string_ascii_mask(byte_vec);
+        if is_zero(ascii_mask) {
+            // this chunk is just ascii, continue to the next chunk
+            index += SIMD_STEP;
+        } else {
+            // this chunk contains either a stop character or a non-ascii character
+            let a: [u8; 16] = unsafe { transmute(byte_vec) };
+            #[allow(clippy::redundant_else)]
+            if let Some(r) = StringChunk::decode_array(a, &mut index, ascii_only) {
+                return r;
+            } else {
+                ascii_only = false;
+            }
+        }
+    }
+    // we got near the end of the string, fall back to the slow path
+    StringChunk::decode_fallback(data, index, ascii_only, allow_partial)
+}
+
+#[rustfmt::skip]
+/// returns a mask where any non-zero byte means we don't have a simple ascii character, either
+/// quote, backslash, control character, or non-ascii (above 127)
+fn string_ascii_mask(byte_vec: SimdVecu8_16) -> SimdVecu8_16 {
+    unsafe {
+        simd_or_16(
+            simd_eq_16(byte_vec, QUOTE_16),
+            simd_or_16(
+                simd_eq_16(byte_vec, BACKSLASH_16),
+                simd_or_16(
+                    simd_gt_16(byte_vec, ASCII_MAX_16),
+                    simd_lt_16(byte_vec, CONTROL_16),
+                )
+            )
+        )
+    }
+}
+
+fn find_end(digit_mask: SimdVecu8_16) -> u32 {
+    let t: [u64; 2] = unsafe { transmute(digit_mask) };
+    if t[0] != 0 {
+        // non-digit in the first 8 bytes
+        t[0].trailing_zeros() / 8
+    } else {
+        t[1].trailing_zeros() / 8 + 8
+    }
+}
+
+/// return true if all bytes are zero
+fn is_zero(vec: SimdVecu8_16) -> bool {
+    let t: [u64; 2] = unsafe { transmute(vec) };
+    t[0] == 0 && t[1] == 0
+}
+
+fn load_slice(bytes: &[u8]) -> SimdVecu8_16 {
+    debug_assert_eq!(bytes.len(), 16);
+    unsafe { simd_load_16(bytes.as_ptr()) }
+}

--- a/merde_json/src/jiter/string_decoder.rs
+++ b/merde_json/src/jiter/string_decoder.rs
@@ -1,0 +1,410 @@
+use std::borrow::Cow;
+use std::ops::Range;
+use std::str::{from_utf8, from_utf8_unchecked};
+
+use crate::jiter::errors::{json_err, json_error, JsonResult};
+
+pub type Tape = Vec<u8>;
+
+/// `'t` is the lifetime of the tape (reusable buffer), `'j` is the lifetime of the JSON data itself
+/// data must outlive tape, so if you return data with the lifetime of tape,
+/// a slice of data the original JSON data is okay too
+pub trait AbstractStringDecoder<'t, 'j>
+where
+    'j: 't,
+{
+    type Output: std::fmt::Debug;
+
+    fn decode(
+        data: &'j [u8],
+        index: usize,
+        tape: &'t mut Tape,
+        allow_partial: bool,
+    ) -> JsonResult<(Self::Output, usize)>;
+}
+
+pub struct StringDecoder;
+
+#[derive(Debug)]
+pub enum StringOutput<'t, 'j>
+where
+    'j: 't,
+{
+    Tape(&'t str, bool),
+    Data(&'j str, bool),
+}
+
+impl From<StringOutput<'_, '_>> for String {
+    fn from(val: StringOutput) -> Self {
+        match val {
+            StringOutput::Tape(s, _) => s.to_owned(),
+            StringOutput::Data(s, _) => s.to_owned(),
+        }
+    }
+}
+
+impl<'t, 'j> From<StringOutput<'t, 'j>> for Cow<'j, str> {
+    fn from(val: StringOutput<'t, 'j>) -> Self {
+        match val {
+            StringOutput::Tape(s, _) => s.to_owned().into(),
+            StringOutput::Data(s, _) => s.into(),
+        }
+    }
+}
+
+impl<'t, 'j> StringOutput<'t, 'j> {
+    pub fn as_str(&self) -> &'t str {
+        match self {
+            Self::Tape(s, _) => s,
+            Self::Data(s, _) => s,
+        }
+    }
+
+    pub fn ascii_only(&self) -> bool {
+        match self {
+            Self::Tape(_, ascii_only) => *ascii_only,
+            Self::Data(_, ascii_only) => *ascii_only,
+        }
+    }
+}
+
+impl<'t, 'j> AbstractStringDecoder<'t, 'j> for StringDecoder
+where
+    'j: 't,
+{
+    type Output = StringOutput<'t, 'j>;
+
+    fn decode(
+        data: &'j [u8],
+        index: usize,
+        tape: &'t mut Tape,
+        allow_partial: bool,
+    ) -> JsonResult<(Self::Output, usize)> {
+        let start = index + 1;
+
+        match decode_chunk(data, start, true, allow_partial)? {
+            (StringChunk::StringEnd, ascii_only, index) => {
+                let s = to_str(&data[start..index], ascii_only, start)?;
+                Ok((StringOutput::Data(s, ascii_only), index + 1))
+            }
+            (StringChunk::Backslash, ascii_only, index) => {
+                decode_to_tape(data, index, tape, start, ascii_only, allow_partial)
+            }
+        }
+    }
+}
+
+fn decode_to_tape<'t, 'j>(
+    data: &'j [u8],
+    mut index: usize,
+    tape: &'t mut Tape,
+    start: usize,
+    mut ascii_only: bool,
+    allow_partial: bool,
+) -> JsonResult<(StringOutput<'t, 'j>, usize)> {
+    tape.clear();
+    let mut chunk_start = start;
+    loop {
+        // on_backslash
+        tape.extend_from_slice(&data[chunk_start..index]);
+        index += 1;
+        if let Some(next_inner) = data.get(index) {
+            match next_inner {
+                b'"' | b'\\' | b'/' => tape.push(*next_inner),
+                b'b' => tape.push(b'\x08'),
+                b'f' => tape.push(b'\x0C'),
+                b'n' => tape.push(b'\n'),
+                b'r' => tape.push(b'\r'),
+                b't' => tape.push(b'\t'),
+                b'u' => {
+                    let (c, new_index) = parse_escape(data, index)?;
+                    ascii_only = false;
+                    index = new_index;
+                    tape.extend_from_slice(c.encode_utf8(&mut [0_u8; 4]).as_bytes());
+                }
+                _ => return json_err!(InvalidEscape, index),
+            }
+            index += 1;
+        } else {
+            return json_err!(EofWhileParsingString, index);
+        }
+
+        match decode_chunk(data, index, ascii_only, allow_partial)? {
+            (StringChunk::StringEnd, ascii_only, new_index) => {
+                tape.extend_from_slice(&data[index..new_index]);
+                index = new_index + 1;
+                let s = to_str(tape, ascii_only, start)?;
+                return Ok((StringOutput::Tape(s, ascii_only), index));
+            }
+            (StringChunk::Backslash, ascii_only_new, index_new) => {
+                ascii_only = ascii_only_new;
+                chunk_start = index;
+                index = index_new;
+            }
+        }
+    }
+}
+
+#[inline(always)]
+pub(crate) fn decode_chunk(
+    data: &[u8],
+    index: usize,
+    ascii_only: bool,
+    allow_partial: bool,
+) -> JsonResult<(StringChunk, bool, usize)> {
+    // TODO x86_64: use simd
+
+    #[cfg(target_arch = "aarch64")]
+    {
+        crate::jiter::simd_aarch64::decode_string_chunk(data, index, ascii_only, allow_partial)
+    }
+    #[cfg(not(target_arch = "aarch64"))]
+    {
+        StringChunk::decode_fallback(data, index, ascii_only, allow_partial)
+    }
+}
+
+pub(crate) enum StringChunk {
+    StringEnd,
+    Backslash,
+}
+
+impl StringChunk {
+    #[inline(always)]
+    pub fn decode_fallback(
+        data: &[u8],
+        mut index: usize,
+        mut ascii_only: bool,
+        allow_partial: bool,
+    ) -> JsonResult<(Self, bool, usize)> {
+        while let Some(next) = data.get(index) {
+            if !JSON_ASCII[*next as usize] {
+                match &CHAR_TYPE[*next as usize] {
+                    CharType::Quote => return Ok((Self::StringEnd, ascii_only, index)),
+                    CharType::Backslash => return Ok((Self::Backslash, ascii_only, index)),
+                    CharType::ControlChar => {
+                        return json_err!(ControlCharacterWhileParsingString, index)
+                    }
+                    CharType::Other => {
+                        ascii_only = false;
+                    }
+                }
+            }
+            index += 1;
+        }
+        if allow_partial {
+            Ok((Self::StringEnd, ascii_only, index))
+        } else {
+            json_err!(EofWhileParsingString, index)
+        }
+    }
+
+    /// decode an array (generally from SIMD) return the result of the chunk, or none if the non-ascii character
+    /// is just > \x7F (127)
+    #[inline(always)]
+    #[allow(dead_code)]
+    pub fn decode_array<const T: usize>(
+        data: [u8; T],
+        index: &mut usize,
+        ascii_only: bool,
+    ) -> Option<JsonResult<(Self, bool, usize)>> {
+        for u8_char in data {
+            if !JSON_ASCII[u8_char as usize] {
+                return match &CHAR_TYPE[u8_char as usize] {
+                    CharType::Quote => Some(Ok((Self::StringEnd, ascii_only, *index))),
+                    CharType::Backslash => Some(Ok((Self::Backslash, ascii_only, *index))),
+                    CharType::ControlChar => {
+                        Some(json_err!(ControlCharacterWhileParsingString, *index))
+                    }
+                    CharType::Other => {
+                        *index += 1;
+                        None
+                    }
+                };
+            }
+            *index += 1;
+        }
+        unreachable!("error decoding SIMD string chunk")
+    }
+}
+
+// taken serde-rs/json but altered
+// https://github.com/serde-rs/json/blob/ebaf61709aba7a3f2429a5d95a694514f180f565/src/read.rs#L787-L811
+// this helps the fast path by telling us if something is ascii or not, it also simplifies
+// CharType below by only requiring 4 options in that enum
+static JSON_ASCII: [bool; 256] = {
+    const CT: bool = false; // control character \x00..=\x1F
+    const QU: bool = false; // quote \x22
+    const BS: bool = false; // backslash \x5C
+    const __: bool = true; // simple ascii
+    const HI: bool = false; // > \x7F (127)
+    [
+        //   1   2   3   4   5   6   7   8   9   A   B   C   D   E   F
+        CT, CT, CT, CT, CT, CT, CT, CT, CT, CT, CT, CT, CT, CT, CT, CT, // 0
+        CT, CT, CT, CT, CT, CT, CT, CT, CT, CT, CT, CT, CT, CT, CT, CT, // 1
+        __, __, QU, __, __, __, __, __, __, __, __, __, __, __, __, __, // 2
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 3
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 4
+        __, __, __, __, __, __, __, __, __, __, __, __, BS, __, __, __, // 5
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 6
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 7
+        HI, HI, HI, HI, HI, HI, HI, HI, HI, HI, HI, HI, HI, HI, HI, HI, // 8
+        HI, HI, HI, HI, HI, HI, HI, HI, HI, HI, HI, HI, HI, HI, HI, HI, // 9
+        HI, HI, HI, HI, HI, HI, HI, HI, HI, HI, HI, HI, HI, HI, HI, HI, // A
+        HI, HI, HI, HI, HI, HI, HI, HI, HI, HI, HI, HI, HI, HI, HI, HI, // B
+        HI, HI, HI, HI, HI, HI, HI, HI, HI, HI, HI, HI, HI, HI, HI, HI, // C
+        HI, HI, HI, HI, HI, HI, HI, HI, HI, HI, HI, HI, HI, HI, HI, HI, // D
+        HI, HI, HI, HI, HI, HI, HI, HI, HI, HI, HI, HI, HI, HI, HI, HI, // E
+        HI, HI, HI, HI, HI, HI, HI, HI, HI, HI, HI, HI, HI, HI, HI, HI, // F
+    ]
+};
+
+enum CharType {
+    // control character \x00..=\x1F
+    ControlChar,
+    // quote \x22
+    Quote,
+    // backslash \x5C
+    Backslash,
+    // all other characters. In reality this will only be > \x7F (127) after the JSON_ASCII check
+    Other,
+}
+
+// Lookup table of bytes that must be escaped. A value of true at index i means
+// that byte i requires an escape sequence in the input.
+static CHAR_TYPE: [CharType; 256] = {
+    const CT: CharType = CharType::ControlChar;
+    const QU: CharType = CharType::Quote;
+    const BS: CharType = CharType::Backslash;
+    const __: CharType = CharType::Other;
+    [
+        //   1   2   3   4   5   6   7   8   9   A   B   C   D   E   F
+        CT, CT, CT, CT, CT, CT, CT, CT, CT, CT, CT, CT, CT, CT, CT, CT, // 0
+        CT, CT, CT, CT, CT, CT, CT, CT, CT, CT, CT, CT, CT, CT, CT, CT, // 1
+        __, __, QU, __, __, __, __, __, __, __, __, __, __, __, __, __, // 2
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 3
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 4
+        __, __, __, __, __, __, __, __, __, __, __, __, BS, __, __, __, // 5
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 6
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 7
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 8
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 9
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // A
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // B
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // C
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // D
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // E
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // F
+    ]
+};
+
+fn to_str(bytes: &[u8], ascii_only: bool, start: usize) -> JsonResult<&str> {
+    if ascii_only {
+        // safety: in this case we've already confirmed that all characters are ascii, we can safely
+        // transmute from bytes to str
+        Ok(unsafe { from_utf8_unchecked(bytes) })
+    } else {
+        from_utf8(bytes)
+            .map_err(|e| json_error!(InvalidUnicodeCodePoint, start + e.valid_up_to() + 1))
+    }
+}
+
+/// Taken approximately from https://github.com/serde-rs/json/blob/v1.0.107/src/read.rs#L872-L945
+fn parse_escape(data: &[u8], index: usize) -> JsonResult<(char, usize)> {
+    let (n, index) = parse_u4(data, index)?;
+    match n {
+        0xDC00..=0xDFFF => json_err!(LoneLeadingSurrogateInHexEscape, index),
+        0xD800..=0xDBFF => match data.get(index + 1..index + 3) {
+            Some(slice) if slice == b"\\u" => {
+                let (n2, index) = parse_u4(data, index + 2)?;
+                if !(0xDC00..=0xDFFF).contains(&n2) {
+                    return json_err!(LoneLeadingSurrogateInHexEscape, index);
+                }
+                let n2 = (((n - 0xD800) as u32) << 10 | (n2 - 0xDC00) as u32) + 0x1_0000;
+
+                match char::from_u32(n2) {
+                    Some(c) => Ok((c, index)),
+                    None => json_err!(EofWhileParsingString, index),
+                }
+            }
+            Some(slice) if slice.starts_with(b"\\") => {
+                json_err!(UnexpectedEndOfHexEscape, index + 2)
+            }
+            Some(_) => json_err!(UnexpectedEndOfHexEscape, index + 1),
+            None => match data.get(index + 1) {
+                Some(b'\\') | None => json_err!(EofWhileParsingString, data.len()),
+                Some(_) => json_err!(UnexpectedEndOfHexEscape, index + 1),
+            },
+        },
+        _ => match char::from_u32(n as u32) {
+            Some(c) => Ok((c, index)),
+            None => json_err!(InvalidEscape, index),
+        },
+    }
+}
+
+fn parse_u4(data: &[u8], mut index: usize) -> JsonResult<(u16, usize)> {
+    let mut n = 0;
+    let u4 = data
+        .get(index + 1..index + 5)
+        .ok_or_else(|| json_error!(EofWhileParsingString, data.len()))?;
+
+    for c in u4 {
+        index += 1;
+        let hex = match c {
+            b'0'..=b'9' => (c & 0x0f) as u16,
+            b'a'..=b'f' => (c - b'a' + 10) as u16,
+            b'A'..=b'F' => (c - b'A' + 10) as u16,
+            _ => return json_err!(InvalidEscape, index),
+        };
+        n = (n << 4) + hex;
+    }
+    Ok((n, index))
+}
+
+/// A string decoder that returns the range of the string.
+///
+/// *WARNING:* For performance reasons, this decoder does not check that the string would be valid UTF-8.
+pub struct StringDecoderRange;
+
+impl<'t, 'j> AbstractStringDecoder<'t, 'j> for StringDecoderRange
+where
+    'j: 't,
+{
+    type Output = Range<usize>;
+
+    fn decode(
+        data: &'j [u8],
+        mut index: usize,
+        _tape: &'t mut Tape,
+        allow_partial: bool,
+    ) -> JsonResult<(Self::Output, usize)> {
+        index += 1;
+        let start = index;
+
+        loop {
+            index = match decode_chunk(data, index, true, allow_partial)? {
+                (StringChunk::StringEnd, _, index) => {
+                    let r = start..index;
+                    return Ok((r, index + 1));
+                }
+                (StringChunk::Backslash, _, index) => index,
+            };
+            index += 1;
+            if let Some(next_inner) = data.get(index) {
+                match next_inner {
+                    // these escapes are easy to validate
+                    b'"' | b'\\' | b'/' | b'b' | b'f' | b'n' | b'r' | b't' => (),
+                    b'u' => {
+                        let (_, new_index) = parse_escape(data, index)?;
+                        index = new_index;
+                    }
+                    _ => return json_err!(InvalidEscape, index),
+                }
+                index += 1;
+            } else {
+                return json_err!(EofWhileParsingString, index);
+            }
+        }
+    }
+}

--- a/merde_json/src/lib.rs
+++ b/merde_json/src/lib.rs
@@ -1,6 +1,7 @@
 #![deny(missing_docs)]
 #![doc = include_str!("../README.md")]
 
+mod jiter;
 mod parser;
 
 use jiter::JiterError;

--- a/zerodeps-example/Cargo.lock
+++ b/zerodeps-example/Cargo.lock
@@ -39,14 +39,14 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "merde"
-version = "3.0.0"
+version = "3.1.1"
 dependencies = [
  "merde_core",
 ]
 
 [[package]]
 name = "merde_core"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "compact_str",
 ]


### PR DESCRIPTION
Instead of depending on jiter (which is biased towards python, comes with its own opinionated `JsonValue` type, etc.