### PR TITLE
Showcase 'impl is not general enough' problem

### DIFF
--- a/merde/Cargo.toml
+++ b/merde/Cargo.toml
@@ -25,6 +25,11 @@ name = "into-static"
 path = "examples/into-static.rs"
 required-features = ["json"]
 
+[[example]]
+name = "return-deserialize"
+path = "examples/return-deserialize.rs"
+required-features = ["json"]
+
 [dependencies]
 merde_core = { version = "4.0.2", path = "../merde_core", optional = true }
 merde_json = { version = "4.0.2", path = "../merde_json", optional = true }

--- a/merde/README.md
+++ b/merde/README.md
@@ -305,7 +305,7 @@ struct Message<'s> {
 }
 
 merde::derive! {
-    impl (ValueDeserialize, JsonSerialize, IntoStatic)
+    impl (ValueDeserialize, JsonSerialize)
     for Message<'s> { kind, payload }
 }
 
@@ -421,7 +421,7 @@ struct Person<'s> {
 }
 
 merde::derive! {
-    impl (ValueDeserialize, JsonSerialize, IntoStatic) for Person<'s> { name, age }
+    impl (ValueDeserialize, JsonSerialize) for Person<'s> { name, age }
 }
 ```
 
@@ -461,7 +461,7 @@ pub struct Person<'s> {
 }
 
 merde::derive! {
-    impl (ValueDeserialize, JsonSerialize, IntoStatic) for Person<'s> { name, age }
+    impl (ValueDeserialize, JsonSerialize) for Person<'s> { name, age }
 }
 ```
 

--- a/merde/examples/into-static.rs
+++ b/merde/examples/into-static.rs
@@ -11,7 +11,7 @@ struct Address<'s> {
 }
 
 merde::derive! {
-    impl (ValueDeserialize, IntoStatic) for Address<'s> {
+    impl (ValueDeserialize) for Address<'s> {
         street,
         city,
         state,
@@ -28,7 +28,7 @@ struct Person<'s> {
 }
 
 merde::derive! {
-    impl (ValueDeserialize, IntoStatic) for Person<'s> { name, age, address }
+    impl (ValueDeserialize) for Person<'s> { name, age, address }
 }
 
 fn get_person() -> Person<'static> {

--- a/merde/examples/mixed.rs
+++ b/merde/examples/mixed.rs
@@ -1,9 +1,5 @@
-use merde::json::JsonSerialize;
-use merde::json::JsonSerializer;
 use merde::CowStr;
-use merde::MerdeError;
 use merde::Value;
-use merde::ValueDeserialize;
 
 #[derive(Debug, PartialEq)]
 struct MixedArray<'s> {
@@ -14,37 +10,8 @@ merde::derive! {
 }
 
 #[derive(Debug, PartialEq)]
-struct Items<'s> {
-    number: u32,
-    string: CowStr<'s>,
-    boolean: bool,
-}
-
-impl<'s> ValueDeserialize<'s> for Items<'s> {
-    fn from_value_ref<'val>(value: Option<&'val Value<'s>>) -> Result<Self, MerdeError> {
-        let arr = value.ok_or(MerdeError::MissingValue)?.as_array()?;
-
-        Ok(Items {
-            number: arr.must_get(0)?,
-            string: arr.must_get(1)?,
-            boolean: arr.must_get(2)?,
-        })
-    }
-}
-
-impl JsonSerialize for Items<'_> {
-    fn json_serialize(&self, serializer: &mut JsonSerializer) {
-        serializer
-            .write_arr()
-            .elem(&self.number)
-            .elem(&self.string)
-            .elem(&self.boolean);
-    }
-}
-
-#[derive(Debug, PartialEq)]
 struct MixedArray2<'s> {
-    items: Items<'s>,
+    items: (u64, CowStr<'s>, bool),
 }
 merde::derive! {
     impl (JsonSerialize, ValueDeserialize) for MixedArray2<'s> { items }

--- a/merde/examples/return-deserialize.rs
+++ b/merde/examples/return-deserialize.rs
@@ -1,0 +1,69 @@
+use merde::json::JsonSerialize;
+use merde::{CowStr, IntoStatic, ValueDeserialize};
+
+fn deser_and_staticify<T>(
+    s: String,
+) -> Result<<T as IntoStatic>::Output, merde_json::MerdeJsonError<'static>>
+where
+    for<'s> T: ValueDeserialize<'s> + IntoStatic,
+{
+    let deserialized: T = merde_json::from_str_via_value(&s).map_err(|e| e.to_static())?;
+    Ok(deserialized.into_static())
+}
+
+fn main() {
+    let input = r#"
+        {
+            "name": "John Doe",
+            "age": 42,
+            "address": {
+                "street": "123 Main St",
+                "city": "Anytown",
+                "state": "CA",
+                "zip": 12345
+            }
+        }
+    "#;
+
+    let person: Person = merde_json::from_str_via_value(input).unwrap();
+    println!("{:?}", person);
+
+    let serialized = person.to_json_string();
+    let person2: Person = merde_json::from_str_via_value(&serialized).unwrap();
+    println!("{:?}", person2);
+
+    assert_eq!(person, person2);
+
+    let person3 = deser_and_staticify::<Person>(serialized).unwrap();
+    println!("{:?}", person3);
+
+    assert_eq!(person, person3);
+}
+
+#[derive(Debug, PartialEq)]
+struct Address<'s> {
+    street: CowStr<'s>,
+    city: CowStr<'s>,
+    state: CowStr<'s>,
+    zip: u16,
+}
+
+merde::derive! {
+    impl (JsonSerialize, ValueDeserialize, IntoStatic) for Address<'s> {
+        street,
+        city,
+        state,
+        zip
+    }
+}
+
+#[derive(Debug, PartialEq)]
+struct Person<'s> {
+    name: CowStr<'s>,
+    age: u8,
+    address: Address<'s>,
+}
+
+merde::derive! {
+    impl (JsonSerialize, ValueDeserialize, IntoStatic) for Person<'s> { name, age, address }
+}

--- a/merde/examples/return-deserialize.rs
+++ b/merde/examples/return-deserialize.rs
@@ -1,13 +1,5 @@
 use merde::json::JsonSerialize;
-use merde::{CowStr, IntoStatic, ValueDeserialize};
-
-trait WithLifetime<'s> {
-    type Lifetimed: 's;
-}
-
-impl<'a, 's> WithLifetime<'s> for Person<'a> {
-    type Lifetimed = Person<'s>;
-}
+use merde::{CowStr, IntoStatic, ValueDeserialize, WithLifetime};
 
 fn deser_and_staticify<T>(s: String) -> Result<T, merde_json::MerdeJsonError<'static>>
 where
@@ -57,7 +49,7 @@ struct Address<'s> {
 }
 
 merde::derive! {
-    impl (JsonSerialize, ValueDeserialize, IntoStatic) for Address<'s> {
+    impl (JsonSerialize, ValueDeserialize) for Address<'s> {
         street,
         city,
         state,
@@ -73,5 +65,5 @@ struct Person<'s> {
 }
 
 merde::derive! {
-    impl (JsonSerialize, ValueDeserialize, IntoStatic) for Person<'s> { name, age, address }
+    impl (JsonSerialize, ValueDeserialize) for Person<'s> { name, age, address }
 }

--- a/merde_core/src/array.rs
+++ b/merde_core/src/array.rs
@@ -1,6 +1,6 @@
 use std::ops::{Deref, DerefMut};
 
-use crate::{value::Value, MerdeError, ValueDeserialize};
+use crate::{value::Value, IntoStatic, MerdeError, ValueDeserialize};
 
 /// An array of [`Value`] items
 #[derive(Debug, PartialEq, Clone)]
@@ -10,6 +10,28 @@ pub struct Array<'s>(pub Vec<Value<'s>>);
 impl<'s> Array<'s> {
     pub fn new() -> Self {
         Array(Vec::new())
+    }
+
+    pub fn into_inner(self) -> Vec<Value<'s>> {
+        self.0
+    }
+}
+
+impl IntoStatic for Array<'_> {
+    type Output = Array<'static>;
+
+    #[inline(always)]
+    fn into_static(self) -> <Self as IntoStatic>::Output {
+        Array(self.0.into_iter().map(|v| v.into_static()).collect())
+    }
+}
+
+impl<'s> IntoIterator for Array<'s> {
+    type Item = Value<'s>;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
     }
 }
 

--- a/merde_core/src/deserialize.rs
+++ b/merde_core/src/deserialize.rs
@@ -182,6 +182,22 @@ impl<'s> ValueDeserialize<'s> for usize {
     }
 }
 
+impl<'s> ValueDeserialize<'s> for isize {
+    fn from_value_ref<'val>(value: Option<&'val Value<'s>>) -> Result<Self, MerdeError> {
+        match value {
+            Some(Value::Int(n)) => (*n).try_into().map_err(|_| MerdeError::OutOfRange),
+            Some(Value::Float(f)) => ((*f).round() as i64)
+                .try_into()
+                .map_err(|_| MerdeError::OutOfRange),
+            Some(v) => Err(MerdeError::MismatchedType {
+                expected: ValueType::Int,
+                found: v.value_type(),
+            }),
+            None => Err(MerdeError::MissingValue),
+        }
+    }
+}
+
 impl<'s> ValueDeserialize<'s> for bool {
     fn from_value_ref<'val>(value: Option<&'val Value<'s>>) -> Result<Self, MerdeError> {
         match value {
@@ -305,5 +321,360 @@ impl<'s> ValueDeserialize<'s> for Map<'s> {
     #[inline(always)]
     fn from_value_ref<'val>(value: Option<&'val Value<'s>>) -> Result<Self, MerdeError> {
         Self::from_value(value.cloned())
+    }
+}
+
+impl<'s, T1> ValueDeserialize<'s> for (T1,)
+where
+    T1: ValueDeserialize<'s>,
+{
+    fn from_value_ref<'val>(value: Option<&'val Value<'s>>) -> Result<Self, MerdeError> {
+        match value {
+            Some(Value::Array(arr)) if arr.len() == 1 => {
+                let t1 = T1::from_value_ref(Some(&arr[0]))?;
+                Ok((t1,))
+            }
+            Some(v) => Err(MerdeError::MismatchedType {
+                expected: ValueType::Array,
+                found: v.value_type(),
+            }),
+            None => Err(MerdeError::MissingValue),
+        }
+    }
+
+    fn from_value(value: Option<Value<'s>>) -> Result<Self, MerdeError> {
+        match value {
+            Some(Value::Array(arr)) if arr.len() == 1 => {
+                let t1 = T1::from_value(Some(arr.into_iter().next().unwrap()))?;
+                Ok((t1,))
+            }
+            Some(v) => Err(MerdeError::MismatchedType {
+                expected: ValueType::Array,
+                found: v.value_type(),
+            }),
+            None => Err(MerdeError::MissingValue),
+        }
+    }
+}
+
+impl<'s, T1, T2> ValueDeserialize<'s> for (T1, T2)
+where
+    T1: ValueDeserialize<'s>,
+    T2: ValueDeserialize<'s>,
+{
+    fn from_value_ref<'val>(value: Option<&'val Value<'s>>) -> Result<Self, MerdeError> {
+        match value {
+            Some(Value::Array(arr)) if arr.len() == 2 => {
+                let t1 = T1::from_value_ref(Some(&arr[0]))?;
+                let t2 = T2::from_value_ref(Some(&arr[1]))?;
+                Ok((t1, t2))
+            }
+            Some(v) => Err(MerdeError::MismatchedType {
+                expected: ValueType::Array,
+                found: v.value_type(),
+            }),
+            None => Err(MerdeError::MissingValue),
+        }
+    }
+
+    fn from_value(value: Option<Value<'s>>) -> Result<Self, MerdeError> {
+        match value {
+            Some(Value::Array(arr)) if arr.len() == 2 => {
+                let mut iter = arr.into_iter();
+                let t1 = T1::from_value(Some(iter.next().unwrap()))?;
+                let t2 = T2::from_value(Some(iter.next().unwrap()))?;
+                Ok((t1, t2))
+            }
+            Some(v) => Err(MerdeError::MismatchedType {
+                expected: ValueType::Array,
+                found: v.value_type(),
+            }),
+            None => Err(MerdeError::MissingValue),
+        }
+    }
+}
+
+impl<'s, T1, T2, T3> ValueDeserialize<'s> for (T1, T2, T3)
+where
+    T1: ValueDeserialize<'s>,
+    T2: ValueDeserialize<'s>,
+    T3: ValueDeserialize<'s>,
+{
+    fn from_value_ref<'val>(value: Option<&'val Value<'s>>) -> Result<Self, MerdeError> {
+        match value {
+            Some(Value::Array(arr)) if arr.len() == 3 => {
+                let t1 = T1::from_value_ref(Some(&arr[0]))?;
+                let t2 = T2::from_value_ref(Some(&arr[1]))?;
+                let t3 = T3::from_value_ref(Some(&arr[2]))?;
+                Ok((t1, t2, t3))
+            }
+            Some(v) => Err(MerdeError::MismatchedType {
+                expected: ValueType::Array,
+                found: v.value_type(),
+            }),
+            None => Err(MerdeError::MissingValue),
+        }
+    }
+
+    fn from_value(value: Option<Value<'s>>) -> Result<Self, MerdeError> {
+        match value {
+            Some(Value::Array(arr)) if arr.len() == 3 => {
+                let mut iter = arr.into_iter();
+                let t1 = T1::from_value(Some(iter.next().unwrap()))?;
+                let t2 = T2::from_value(Some(iter.next().unwrap()))?;
+                let t3 = T3::from_value(Some(iter.next().unwrap()))?;
+                Ok((t1, t2, t3))
+            }
+            Some(v) => Err(MerdeError::MismatchedType {
+                expected: ValueType::Array,
+                found: v.value_type(),
+            }),
+            None => Err(MerdeError::MissingValue),
+        }
+    }
+}
+
+impl<'s, T1, T2, T3, T4> ValueDeserialize<'s> for (T1, T2, T3, T4)
+where
+    T1: ValueDeserialize<'s>,
+    T2: ValueDeserialize<'s>,
+    T3: ValueDeserialize<'s>,
+    T4: ValueDeserialize<'s>,
+{
+    fn from_value_ref<'val>(value: Option<&'val Value<'s>>) -> Result<Self, MerdeError> {
+        match value {
+            Some(Value::Array(arr)) if arr.len() == 4 => {
+                let t1 = T1::from_value_ref(Some(&arr[0]))?;
+                let t2 = T2::from_value_ref(Some(&arr[1]))?;
+                let t3 = T3::from_value_ref(Some(&arr[2]))?;
+                let t4 = T4::from_value_ref(Some(&arr[3]))?;
+                Ok((t1, t2, t3, t4))
+            }
+            Some(v) => Err(MerdeError::MismatchedType {
+                expected: ValueType::Array,
+                found: v.value_type(),
+            }),
+            None => Err(MerdeError::MissingValue),
+        }
+    }
+
+    fn from_value(value: Option<Value<'s>>) -> Result<Self, MerdeError> {
+        match value {
+            Some(Value::Array(arr)) if arr.len() == 4 => {
+                let mut iter = arr.into_iter();
+                let t1 = T1::from_value(Some(iter.next().unwrap()))?;
+                let t2 = T2::from_value(Some(iter.next().unwrap()))?;
+                let t3 = T3::from_value(Some(iter.next().unwrap()))?;
+                let t4 = T4::from_value(Some(iter.next().unwrap()))?;
+                Ok((t1, t2, t3, t4))
+            }
+            Some(v) => Err(MerdeError::MismatchedType {
+                expected: ValueType::Array,
+                found: v.value_type(),
+            }),
+            None => Err(MerdeError::MissingValue),
+        }
+    }
+}
+
+impl<'s, T1, T2, T3, T4, T5> ValueDeserialize<'s> for (T1, T2, T3, T4, T5)
+where
+    T1: ValueDeserialize<'s>,
+    T2: ValueDeserialize<'s>,
+    T3: ValueDeserialize<'s>,
+    T4: ValueDeserialize<'s>,
+    T5: ValueDeserialize<'s>,
+{
+    fn from_value_ref<'val>(value: Option<&'val Value<'s>>) -> Result<Self, MerdeError> {
+        match value {
+            Some(Value::Array(arr)) if arr.len() == 5 => {
+                let t1 = T1::from_value_ref(Some(&arr[0]))?;
+                let t2 = T2::from_value_ref(Some(&arr[1]))?;
+                let t3 = T3::from_value_ref(Some(&arr[2]))?;
+                let t4 = T4::from_value_ref(Some(&arr[3]))?;
+                let t5 = T5::from_value_ref(Some(&arr[4]))?;
+                Ok((t1, t2, t3, t4, t5))
+            }
+            Some(v) => Err(MerdeError::MismatchedType {
+                expected: ValueType::Array,
+                found: v.value_type(),
+            }),
+            None => Err(MerdeError::MissingValue),
+        }
+    }
+
+    fn from_value(value: Option<Value<'s>>) -> Result<Self, MerdeError> {
+        match value {
+            Some(Value::Array(arr)) if arr.len() == 5 => {
+                let mut iter = arr.into_iter();
+                let t1 = T1::from_value(Some(iter.next().unwrap()))?;
+                let t2 = T2::from_value(Some(iter.next().unwrap()))?;
+                let t3 = T3::from_value(Some(iter.next().unwrap()))?;
+                let t4 = T4::from_value(Some(iter.next().unwrap()))?;
+                let t5 = T5::from_value(Some(iter.next().unwrap()))?;
+                Ok((t1, t2, t3, t4, t5))
+            }
+            Some(v) => Err(MerdeError::MismatchedType {
+                expected: ValueType::Array,
+                found: v.value_type(),
+            }),
+            None => Err(MerdeError::MissingValue),
+        }
+    }
+}
+
+impl<'s, T1, T2, T3, T4, T5, T6> ValueDeserialize<'s> for (T1, T2, T3, T4, T5, T6)
+where
+    T1: ValueDeserialize<'s>,
+    T2: ValueDeserialize<'s>,
+    T3: ValueDeserialize<'s>,
+    T4: ValueDeserialize<'s>,
+    T5: ValueDeserialize<'s>,
+    T6: ValueDeserialize<'s>,
+{
+    fn from_value_ref<'val>(value: Option<&'val Value<'s>>) -> Result<Self, MerdeError> {
+        match value {
+            Some(Value::Array(arr)) if arr.len() == 6 => {
+                let t1 = T1::from_value_ref(Some(&arr[0]))?;
+                let t2 = T2::from_value_ref(Some(&arr[1]))?;
+                let t3 = T3::from_value_ref(Some(&arr[2]))?;
+                let t4 = T4::from_value_ref(Some(&arr[3]))?;
+                let t5 = T5::from_value_ref(Some(&arr[4]))?;
+                let t6 = T6::from_value_ref(Some(&arr[5]))?;
+                Ok((t1, t2, t3, t4, t5, t6))
+            }
+            Some(v) => Err(MerdeError::MismatchedType {
+                expected: ValueType::Array,
+                found: v.value_type(),
+            }),
+            None => Err(MerdeError::MissingValue),
+        }
+    }
+
+    fn from_value(value: Option<Value<'s>>) -> Result<Self, MerdeError> {
+        match value {
+            Some(Value::Array(arr)) if arr.len() == 6 => {
+                let mut iter = arr.into_iter();
+                let t1 = T1::from_value(Some(iter.next().unwrap()))?;
+                let t2 = T2::from_value(Some(iter.next().unwrap()))?;
+                let t3 = T3::from_value(Some(iter.next().unwrap()))?;
+                let t4 = T4::from_value(Some(iter.next().unwrap()))?;
+                let t5 = T5::from_value(Some(iter.next().unwrap()))?;
+                let t6 = T6::from_value(Some(iter.next().unwrap()))?;
+                Ok((t1, t2, t3, t4, t5, t6))
+            }
+            Some(v) => Err(MerdeError::MismatchedType {
+                expected: ValueType::Array,
+                found: v.value_type(),
+            }),
+            None => Err(MerdeError::MissingValue),
+        }
+    }
+}
+
+impl<'s, T1, T2, T3, T4, T5, T6, T7> ValueDeserialize<'s> for (T1, T2, T3, T4, T5, T6, T7)
+where
+    T1: ValueDeserialize<'s>,
+    T2: ValueDeserialize<'s>,
+    T3: ValueDeserialize<'s>,
+    T4: ValueDeserialize<'s>,
+    T5: ValueDeserialize<'s>,
+    T6: ValueDeserialize<'s>,
+    T7: ValueDeserialize<'s>,
+{
+    fn from_value_ref<'val>(value: Option<&'val Value<'s>>) -> Result<Self, MerdeError> {
+        match value {
+            Some(Value::Array(arr)) if arr.len() == 7 => {
+                let t1 = T1::from_value_ref(Some(&arr[0]))?;
+                let t2 = T2::from_value_ref(Some(&arr[1]))?;
+                let t3 = T3::from_value_ref(Some(&arr[2]))?;
+                let t4 = T4::from_value_ref(Some(&arr[3]))?;
+                let t5 = T5::from_value_ref(Some(&arr[4]))?;
+                let t6 = T6::from_value_ref(Some(&arr[5]))?;
+                let t7 = T7::from_value_ref(Some(&arr[6]))?;
+                Ok((t1, t2, t3, t4, t5, t6, t7))
+            }
+            Some(v) => Err(MerdeError::MismatchedType {
+                expected: ValueType::Array,
+                found: v.value_type(),
+            }),
+            None => Err(MerdeError::MissingValue),
+        }
+    }
+
+    fn from_value(value: Option<Value<'s>>) -> Result<Self, MerdeError> {
+        match value {
+            Some(Value::Array(arr)) if arr.len() == 7 => {
+                let mut iter = arr.into_iter();
+                let t1 = T1::from_value(Some(iter.next().unwrap()))?;
+                let t2 = T2::from_value(Some(iter.next().unwrap()))?;
+                let t3 = T3::from_value(Some(iter.next().unwrap()))?;
+                let t4 = T4::from_value(Some(iter.next().unwrap()))?;
+                let t5 = T5::from_value(Some(iter.next().unwrap()))?;
+                let t6 = T6::from_value(Some(iter.next().unwrap()))?;
+                let t7 = T7::from_value(Some(iter.next().unwrap()))?;
+                Ok((t1, t2, t3, t4, t5, t6, t7))
+            }
+            Some(v) => Err(MerdeError::MismatchedType {
+                expected: ValueType::Array,
+                found: v.value_type(),
+            }),
+            None => Err(MerdeError::MissingValue),
+        }
+    }
+}
+
+impl<'s, T1, T2, T3, T4, T5, T6, T7, T8> ValueDeserialize<'s> for (T1, T2, T3, T4, T5, T6, T7, T8)
+where
+    T1: ValueDeserialize<'s>,
+    T2: ValueDeserialize<'s>,
+    T3: ValueDeserialize<'s>,
+    T4: ValueDeserialize<'s>,
+    T5: ValueDeserialize<'s>,
+    T6: ValueDeserialize<'s>,
+    T7: ValueDeserialize<'s>,
+    T8: ValueDeserialize<'s>,
+{
+    fn from_value_ref<'val>(value: Option<&'val Value<'s>>) -> Result<Self, MerdeError> {
+        match value {
+            Some(Value::Array(arr)) if arr.len() == 8 => {
+                let t1 = T1::from_value_ref(Some(&arr[0]))?;
+                let t2 = T2::from_value_ref(Some(&arr[1]))?;
+                let t3 = T3::from_value_ref(Some(&arr[2]))?;
+                let t4 = T4::from_value_ref(Some(&arr[3]))?;
+                let t5 = T5::from_value_ref(Some(&arr[4]))?;
+                let t6 = T6::from_value_ref(Some(&arr[5]))?;
+                let t7 = T7::from_value_ref(Some(&arr[6]))?;
+                let t8 = T8::from_value_ref(Some(&arr[7]))?;
+                Ok((t1, t2, t3, t4, t5, t6, t7, t8))
+            }
+            Some(v) => Err(MerdeError::MismatchedType {
+                expected: ValueType::Array,
+                found: v.value_type(),
+            }),
+            None => Err(MerdeError::MissingValue),
+        }
+    }
+
+    fn from_value(value: Option<Value<'s>>) -> Result<Self, MerdeError> {
+        match value {
+            Some(Value::Array(arr)) if arr.len() == 8 => {
+                let mut iter = arr.into_iter();
+                let t1 = T1::from_value(Some(iter.next().unwrap()))?;
+                let t2 = T2::from_value(Some(iter.next().unwrap()))?;
+                let t3 = T3::from_value(Some(iter.next().unwrap()))?;
+                let t4 = T4::from_value(Some(iter.next().unwrap()))?;
+                let t5 = T5::from_value(Some(iter.next().unwrap()))?;
+                let t6 = T6::from_value(Some(iter.next().unwrap()))?;
+                let t7 = T7::from_value(Some(iter.next().unwrap()))?;
+                let t8 = T8::from_value(Some(iter.next().unwrap()))?;
+                Ok((t1, t2, t3, t4, t5, t6, t7, t8))
+            }
+            Some(v) => Err(MerdeError::MismatchedType {
+                expected: ValueType::Array,
+                found: v.value_type(),
+            }),
+            None => Err(MerdeError::MissingValue),
+        }
     }
 }

--- a/merde_core/src/into_static.rs
+++ b/merde_core/src/into_static.rs
@@ -24,6 +24,7 @@ where
 {
     type Output = Cow<'static, T>;
 
+    #[inline(always)]
     fn into_static(self) -> Self::Output {
         match self {
             Cow::Borrowed(b) => Cow::Owned(b.to_owned()),
@@ -33,7 +34,7 @@ where
 }
 
 macro_rules! impl_into_static_passthru {
-    (($($ty:ty),+)) => {
+    ($($ty:ty),+) => {
         $(
             impl IntoStatic for $ty {
                 type Output = $ty;
@@ -47,9 +48,9 @@ macro_rules! impl_into_static_passthru {
     };
 }
 
-impl_into_static_passthru!((
-    u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, usize, isize, bool, String
-));
+impl_into_static_passthru!(
+    String, u128, u64, u32, u16, u8, i128, i64, i32, i16, i8, bool, char, f32, f64, usize, isize
+);
 
 impl<T: IntoStatic> IntoStatic for Option<T> {
     type Output = Option<T::Output>;
@@ -98,5 +99,163 @@ impl<T: IntoStatic> IntoStatic for VecDeque<T> {
 
     fn into_static(self) -> Self::Output {
         self.into_iter().map(|v| v.into_static()).collect()
+    }
+}
+
+impl<T1: IntoStatic> IntoStatic for (T1,) {
+    type Output = (T1::Output,);
+
+    fn into_static(self) -> Self::Output {
+        (self.0.into_static(),)
+    }
+}
+
+impl<T1: IntoStatic, T2: IntoStatic> IntoStatic for (T1, T2) {
+    type Output = (T1::Output, T2::Output);
+
+    fn into_static(self) -> Self::Output {
+        (self.0.into_static(), self.1.into_static())
+    }
+}
+
+impl<T1: IntoStatic, T2: IntoStatic, T3: IntoStatic> IntoStatic for (T1, T2, T3) {
+    type Output = (T1::Output, T2::Output, T3::Output);
+
+    fn into_static(self) -> Self::Output {
+        (
+            self.0.into_static(),
+            self.1.into_static(),
+            self.2.into_static(),
+        )
+    }
+}
+
+impl<T1: IntoStatic, T2: IntoStatic, T3: IntoStatic, T4: IntoStatic> IntoStatic
+    for (T1, T2, T3, T4)
+{
+    type Output = (T1::Output, T2::Output, T3::Output, T4::Output);
+
+    fn into_static(self) -> Self::Output {
+        (
+            self.0.into_static(),
+            self.1.into_static(),
+            self.2.into_static(),
+            self.3.into_static(),
+        )
+    }
+}
+
+impl<T1: IntoStatic, T2: IntoStatic, T3: IntoStatic, T4: IntoStatic, T5: IntoStatic> IntoStatic
+    for (T1, T2, T3, T4, T5)
+{
+    type Output = (T1::Output, T2::Output, T3::Output, T4::Output, T5::Output);
+
+    fn into_static(self) -> Self::Output {
+        (
+            self.0.into_static(),
+            self.1.into_static(),
+            self.2.into_static(),
+            self.3.into_static(),
+            self.4.into_static(),
+        )
+    }
+}
+
+impl<
+        T1: IntoStatic,
+        T2: IntoStatic,
+        T3: IntoStatic,
+        T4: IntoStatic,
+        T5: IntoStatic,
+        T6: IntoStatic,
+    > IntoStatic for (T1, T2, T3, T4, T5, T6)
+{
+    type Output = (
+        T1::Output,
+        T2::Output,
+        T3::Output,
+        T4::Output,
+        T5::Output,
+        T6::Output,
+    );
+
+    fn into_static(self) -> Self::Output {
+        (
+            self.0.into_static(),
+            self.1.into_static(),
+            self.2.into_static(),
+            self.3.into_static(),
+            self.4.into_static(),
+            self.5.into_static(),
+        )
+    }
+}
+
+impl<
+        T1: IntoStatic,
+        T2: IntoStatic,
+        T3: IntoStatic,
+        T4: IntoStatic,
+        T5: IntoStatic,
+        T6: IntoStatic,
+        T7: IntoStatic,
+    > IntoStatic for (T1, T2, T3, T4, T5, T6, T7)
+{
+    type Output = (
+        T1::Output,
+        T2::Output,
+        T3::Output,
+        T4::Output,
+        T5::Output,
+        T6::Output,
+        T7::Output,
+    );
+
+    fn into_static(self) -> Self::Output {
+        (
+            self.0.into_static(),
+            self.1.into_static(),
+            self.2.into_static(),
+            self.3.into_static(),
+            self.4.into_static(),
+            self.5.into_static(),
+            self.6.into_static(),
+        )
+    }
+}
+
+impl<
+        T1: IntoStatic,
+        T2: IntoStatic,
+        T3: IntoStatic,
+        T4: IntoStatic,
+        T5: IntoStatic,
+        T6: IntoStatic,
+        T7: IntoStatic,
+        T8: IntoStatic,
+    > IntoStatic for (T1, T2, T3, T4, T5, T6, T7, T8)
+{
+    type Output = (
+        T1::Output,
+        T2::Output,
+        T3::Output,
+        T4::Output,
+        T5::Output,
+        T6::Output,
+        T7::Output,
+        T8::Output,
+    );
+
+    fn into_static(self) -> Self::Output {
+        (
+            self.0.into_static(),
+            self.1.into_static(),
+            self.2.into_static(),
+            self.3.into_static(),
+            self.4.into_static(),
+            self.5.into_static(),
+            self.6.into_static(),
+            self.7.into_static(),
+        )
     }
 }

--- a/merde_core/src/lib.rs
+++ b/merde_core/src/lib.rs
@@ -14,6 +14,9 @@ pub use error::ValueType;
 mod into_static;
 pub use into_static::IntoStatic;
 
+mod with_lifetime;
+pub use with_lifetime::WithLifetime;
+
 mod value;
 pub use value::Value;
 

--- a/merde_core/src/lib.rs
+++ b/merde_core/src/lib.rs
@@ -21,6 +21,7 @@ mod value;
 pub use value::Value;
 
 mod deserialize;
+pub use deserialize::OwnedValueDeserialize;
 pub use deserialize::ValueDeserialize;
 
 /// Interpret a &[`Value`] as an instance of type `T`. This may involve

--- a/merde_core/src/with_lifetime.rs
+++ b/merde_core/src/with_lifetime.rs
@@ -1,0 +1,208 @@
+use std::{
+    borrow::Cow,
+    collections::{HashMap, HashSet, VecDeque},
+};
+
+use crate::CowStr;
+
+/// Allow instantiating a type with a lifetime parameter, which in
+/// turn lets us require `ValueDeserialize<'s>` for `CowStr<'s>` for
+/// example, even when `CowStr<'s>` is erased behind a `T`.
+///
+/// See <https://github.com/bearcove/merde/pull/60> for details
+pub trait WithLifetime<'s> {
+    type Lifetimed: 's;
+}
+
+macro_rules! impl_with_lifetime {
+    ($($struct_name:ident $(<$lifetime:lifetime>)?),* $(,)?) => {
+        $(
+            impl_with_lifetime!(@inner $struct_name $(<$lifetime>)?);
+        )*
+    };
+
+    (@inner $struct_name:ident <$lifetime:lifetime>) => {
+        impl<$lifetime, 'instantiated_lifetime> WithLifetime<'instantiated_lifetime>
+            for $struct_name<$lifetime>
+        {
+            type Lifetimed = $struct_name<'instantiated_lifetime>;
+        }
+    };
+
+    (@inner $struct_name:ident) => {
+        impl<'s> WithLifetime<'s> for $struct_name {
+            type Lifetimed = $struct_name;
+        }
+    };
+}
+
+impl<'a, 's, B: ToOwned + ?Sized + 's> WithLifetime<'s> for Cow<'a, B> {
+    type Lifetimed = Cow<'s, B>;
+}
+
+impl<'a, 's> WithLifetime<'s> for &'a str {
+    type Lifetimed = &'s str;
+}
+
+impl_with_lifetime!(
+    CowStr<'s>,
+    String,
+    u128,
+    u64,
+    u32,
+    u16,
+    u8,
+    i128,
+    i64,
+    i32,
+    i16,
+    i8,
+    bool,
+    char,
+    f32,
+    f64,
+    usize,
+    isize,
+);
+
+impl<'s> WithLifetime<'s> for () {
+    type Lifetimed = ();
+}
+
+impl<'s, T> WithLifetime<'s> for Vec<T>
+where
+    T: WithLifetime<'s>,
+{
+    type Lifetimed = Vec<T::Lifetimed>;
+}
+
+impl<'s, T> WithLifetime<'s> for VecDeque<T>
+where
+    T: WithLifetime<'s>,
+{
+    type Lifetimed = VecDeque<T::Lifetimed>;
+}
+
+impl<'s, T> WithLifetime<'s> for HashSet<T>
+where
+    T: WithLifetime<'s>,
+{
+    type Lifetimed = HashSet<T::Lifetimed>;
+}
+
+impl<'s, K, V> WithLifetime<'s> for HashMap<K, V>
+where
+    K: WithLifetime<'s>,
+    V: WithLifetime<'s>,
+{
+    type Lifetimed = HashMap<K::Lifetimed, V::Lifetimed>;
+}
+
+impl<'s, T1: WithLifetime<'s>> WithLifetime<'s> for (T1,) {
+    type Lifetimed = (T1::Lifetimed,);
+}
+
+impl<'s, T1: WithLifetime<'s>, T2: WithLifetime<'s>> WithLifetime<'s> for (T1, T2) {
+    type Lifetimed = (T1::Lifetimed, T2::Lifetimed);
+}
+
+impl<'s, T1: WithLifetime<'s>, T2: WithLifetime<'s>, T3: WithLifetime<'s>> WithLifetime<'s>
+    for (T1, T2, T3)
+{
+    type Lifetimed = (T1::Lifetimed, T2::Lifetimed, T3::Lifetimed);
+}
+
+impl<
+        's,
+        T1: WithLifetime<'s>,
+        T2: WithLifetime<'s>,
+        T3: WithLifetime<'s>,
+        T4: WithLifetime<'s>,
+    > WithLifetime<'s> for (T1, T2, T3, T4)
+{
+    type Lifetimed = (T1::Lifetimed, T2::Lifetimed, T3::Lifetimed, T4::Lifetimed);
+}
+
+impl<
+        's,
+        T1: WithLifetime<'s>,
+        T2: WithLifetime<'s>,
+        T3: WithLifetime<'s>,
+        T4: WithLifetime<'s>,
+        T5: WithLifetime<'s>,
+    > WithLifetime<'s> for (T1, T2, T3, T4, T5)
+{
+    type Lifetimed = (
+        T1::Lifetimed,
+        T2::Lifetimed,
+        T3::Lifetimed,
+        T4::Lifetimed,
+        T5::Lifetimed,
+    );
+}
+
+impl<
+        's,
+        T1: WithLifetime<'s>,
+        T2: WithLifetime<'s>,
+        T3: WithLifetime<'s>,
+        T4: WithLifetime<'s>,
+        T5: WithLifetime<'s>,
+        T6: WithLifetime<'s>,
+    > WithLifetime<'s> for (T1, T2, T3, T4, T5, T6)
+{
+    type Lifetimed = (
+        T1::Lifetimed,
+        T2::Lifetimed,
+        T3::Lifetimed,
+        T4::Lifetimed,
+        T5::Lifetimed,
+        T6::Lifetimed,
+    );
+}
+
+impl<
+        's,
+        T1: WithLifetime<'s>,
+        T2: WithLifetime<'s>,
+        T3: WithLifetime<'s>,
+        T4: WithLifetime<'s>,
+        T5: WithLifetime<'s>,
+        T6: WithLifetime<'s>,
+        T7: WithLifetime<'s>,
+    > WithLifetime<'s> for (T1, T2, T3, T4, T5, T6, T7)
+{
+    type Lifetimed = (
+        T1::Lifetimed,
+        T2::Lifetimed,
+        T3::Lifetimed,
+        T4::Lifetimed,
+        T5::Lifetimed,
+        T6::Lifetimed,
+        T7::Lifetimed,
+    );
+}
+
+impl<
+        's,
+        T1: WithLifetime<'s>,
+        T2: WithLifetime<'s>,
+        T3: WithLifetime<'s>,
+        T4: WithLifetime<'s>,
+        T5: WithLifetime<'s>,
+        T6: WithLifetime<'s>,
+        T7: WithLifetime<'s>,
+        T8: WithLifetime<'s>,
+    > WithLifetime<'s> for (T1, T2, T3, T4, T5, T6, T7, T8)
+{
+    type Lifetimed = (
+        T1::Lifetimed,
+        T2::Lifetimed,
+        T3::Lifetimed,
+        T4::Lifetimed,
+        T5::Lifetimed,
+        T6::Lifetimed,
+        T7::Lifetimed,
+        T8::Lifetimed,
+    );
+}

--- a/merde_json/src/lib.rs
+++ b/merde_json/src/lib.rs
@@ -365,12 +365,123 @@ impl<T: JsonSerialize> JsonSerialize for &[T] {
     }
 }
 
-impl<V: JsonSerialize> JsonSerialize for &[(&str, V)] {
+impl<T1: JsonSerialize> JsonSerialize for (T1,) {
     fn json_serialize(&self, serializer: &mut JsonSerializer) {
-        let mut guard = serializer.write_obj();
-        for (key, value) in *self {
-            guard.pair(key.as_ref(), value);
-        }
+        let mut guard = serializer.write_arr();
+        guard.elem(&self.0);
+    }
+}
+
+impl<T1: JsonSerialize, T2: JsonSerialize> JsonSerialize for (T1, T2) {
+    fn json_serialize(&self, serializer: &mut JsonSerializer) {
+        let mut guard = serializer.write_arr();
+        guard.elem(&self.0);
+        guard.elem(&self.1);
+    }
+}
+
+impl<T1: JsonSerialize, T2: JsonSerialize, T3: JsonSerialize> JsonSerialize for (T1, T2, T3) {
+    fn json_serialize(&self, serializer: &mut JsonSerializer) {
+        let mut guard = serializer.write_arr();
+        guard.elem(&self.0);
+        guard.elem(&self.1);
+        guard.elem(&self.2);
+    }
+}
+
+impl<T1: JsonSerialize, T2: JsonSerialize, T3: JsonSerialize, T4: JsonSerialize> JsonSerialize
+    for (T1, T2, T3, T4)
+{
+    fn json_serialize(&self, serializer: &mut JsonSerializer) {
+        let mut guard = serializer.write_arr();
+        guard.elem(&self.0);
+        guard.elem(&self.1);
+        guard.elem(&self.2);
+        guard.elem(&self.3);
+    }
+}
+
+impl<
+        T1: JsonSerialize,
+        T2: JsonSerialize,
+        T3: JsonSerialize,
+        T4: JsonSerialize,
+        T5: JsonSerialize,
+    > JsonSerialize for (T1, T2, T3, T4, T5)
+{
+    fn json_serialize(&self, serializer: &mut JsonSerializer) {
+        let mut guard = serializer.write_arr();
+        guard.elem(&self.0);
+        guard.elem(&self.1);
+        guard.elem(&self.2);
+        guard.elem(&self.3);
+        guard.elem(&self.4);
+    }
+}
+
+impl<
+        T1: JsonSerialize,
+        T2: JsonSerialize,
+        T3: JsonSerialize,
+        T4: JsonSerialize,
+        T5: JsonSerialize,
+        T6: JsonSerialize,
+    > JsonSerialize for (T1, T2, T3, T4, T5, T6)
+{
+    fn json_serialize(&self, serializer: &mut JsonSerializer) {
+        let mut guard = serializer.write_arr();
+        guard.elem(&self.0);
+        guard.elem(&self.1);
+        guard.elem(&self.2);
+        guard.elem(&self.3);
+        guard.elem(&self.4);
+        guard.elem(&self.5);
+    }
+}
+
+impl<
+        T1: JsonSerialize,
+        T2: JsonSerialize,
+        T3: JsonSerialize,
+        T4: JsonSerialize,
+        T5: JsonSerialize,
+        T6: JsonSerialize,
+        T7: JsonSerialize,
+    > JsonSerialize for (T1, T2, T3, T4, T5, T6, T7)
+{
+    fn json_serialize(&self, serializer: &mut JsonSerializer) {
+        let mut guard = serializer.write_arr();
+        guard.elem(&self.0);
+        guard.elem(&self.1);
+        guard.elem(&self.2);
+        guard.elem(&self.3);
+        guard.elem(&self.4);
+        guard.elem(&self.5);
+        guard.elem(&self.6);
+    }
+}
+
+impl<
+        T1: JsonSerialize,
+        T2: JsonSerialize,
+        T3: JsonSerialize,
+        T4: JsonSerialize,
+        T5: JsonSerialize,
+        T6: JsonSerialize,
+        T7: JsonSerialize,
+        T8: JsonSerialize,
+    > JsonSerialize for (T1, T2, T3, T4, T5, T6, T7, T8)
+{
+    fn json_serialize(&self, serializer: &mut JsonSerializer) {
+        let mut guard = serializer.write_arr();
+        guard.elem(&self.0);
+        guard.elem(&self.1);
+        guard.elem(&self.2);
+        guard.elem(&self.3);
+        guard.elem(&self.4);
+        guard.elem(&self.5);
+        guard.elem(&self.6);
+        guard.elem(&self.7);
     }
 }
 

--- a/merde_json/src/lib.rs
+++ b/merde_json/src/lib.rs
@@ -5,7 +5,9 @@ mod jiter_lite;
 mod parser;
 
 use jiter_lite::errors::JiterError;
-use merde_core::{Array, CowStr, IntoStatic, Map, MerdeError, Value, ValueDeserialize};
+use merde_core::{
+    Array, CowStr, IntoStatic, Map, MerdeError, OwnedValueDeserialize, Value, ValueDeserialize,
+};
 use parser::json_bytes_to_value;
 
 use std::borrow::Cow;
@@ -595,6 +597,21 @@ where
         source: Some(s.into()),
     })?;
     Ok(merde_core::from_value(value)?)
+}
+
+/// Deserialize an instance of type `T` from a string of JSON text, making
+/// sure the result is owned.
+pub fn owned_from_str_via_value<T>(s: &str) -> Result<T, MerdeJsonError<'_>>
+where
+    T: OwnedValueDeserialize,
+{
+    let value = json_bytes_to_value(s.as_bytes()).map_err(|e| MerdeJsonError::JiterError {
+        err: e,
+        source: Some(s.into()),
+    })?;
+    Ok(merde_core::OwnedValueDeserialize::owned_from_value(Some(
+        value,
+    ))?)
 }
 
 /// Serialize the given data structure as a String of JSON.

--- a/zerodeps-example/Cargo.lock
+++ b/zerodeps-example/Cargo.lock
@@ -39,7 +39,7 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "merde"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "merde_core",
 ]

--- a/zerodeps-example/src/lib.rs
+++ b/zerodeps-example/src/lib.rs
@@ -11,5 +11,5 @@ pub struct Person<'s> {
 }
 
 merde::derive! {
-    impl (ValueDeserialize, JsonSerialize, IntoStatic) for Person<'s> { name, age }
+    impl (ValueDeserialize, JsonSerialize) for Person<'s> { name, age }
 }


### PR DESCRIPTION
Can anyone think of solution to this?

```
merde on  not-general-enough [$] via 🦀 v1.81.0
❯ cargo run --features json --example return-deserialize
   Compiling merde v4.0.5 (/Users/amos/bearcove/merde/merde)
error: implementation of `ValueDeserialize` is not general enough
  --> merde/examples/return-deserialize.rs:37:19
   |
37 |     let person3 = deser_and_staticify::<Person>(serialized).unwrap();
   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `ValueDeserialize` is not general enough
   |
   = note: `ValueDeserialize<'0>` would have to be implemented for the type `Person<'_>`, for any lifetime `'0`...
   = note: ...but `ValueDeserialize<'1>` is actually implemented for the type `Person<'1>`, for some specific lifetime `'1`

error: could not compile `merde` (example "return-deserialize") due to 1 previous error
```

for this code:

```rust
use merde::json::JsonSerialize;
use merde::{CowStr, IntoStatic, ValueDeserialize};

fn deser_and_staticify<T>(
    s: String,
) -> Result<<T as IntoStatic>::Output, merde_json::MerdeJsonError<'static>>
where
    for<'s> T: ValueDeserialize<'s> + IntoStatic,
{
    let deserialized: T = merde_json::from_str_via_value(&s).map_err(|e| e.to_static())?;
    Ok(deserialized.into_static())
}

fn main() {
    let input = r#"
        {
            "name": "John Doe",
            "age": 42,
            "address": {
                "street": "123 Main St",
                "city": "Anytown",
                "state": "CA",
                "zip": 12345
            }
        }
    "#;

    let person: Person = merde_json::from_str_via_value(input).unwrap();
    println!("{:?}", person);

    let serialized = person.to_json_string();
    let person2: Person = merde_json::from_str_via_value(&serialized).unwrap();
    println!("{:?}", person2);

    assert_eq!(person, person2);

    let person3 = deser_and_staticify::<Person>(serialized).unwrap();
    println!("{:?}", person3);

    assert_eq!(person, person3);
}

#[derive(Debug, PartialEq)]
struct Address<'s> {
    street: CowStr<'s>,
    city: CowStr<'s>,
    state: CowStr<'s>,
    zip: u16,
}

merde::derive! {
    impl (JsonSerialize, ValueDeserialize, IntoStatic) for Address<'s> {
        street,
        city,
        state,
        zip
    }
}

#[derive(Debug, PartialEq)]
struct Person<'s> {
    name: CowStr<'s>,
    age: u8,
    address: Address<'s>,
}

merde::derive! {
    impl (JsonSerialize, ValueDeserialize, IntoStatic) for Person<'s> { name, age, address }
}
```

alternatively, you can check out the branch and run:

```shell
cargo run --features json --example return-deserialize
```

yourself.