### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -317,7 +317,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "merde"
-version = "6.2.1"
+version = "6.2.2"
 dependencies = [
  "ahash",
  "merde_core",
@@ -329,7 +329,7 @@ dependencies = [
 
 [[package]]
 name = "merde_core"
-version = "7.0.0"
+version = "8.0.0"
 dependencies = [
  "compact_bytes",
  "compact_str",
@@ -344,7 +344,7 @@ dependencies = [
 
 [[package]]
 name = "merde_json"
-version = "6.2.1"
+version = "7.0.0"
 dependencies = [
  "itoa",
  "lexical-parse-float",
@@ -365,7 +365,7 @@ dependencies = [
 
 [[package]]
 name = "merde_msgpack"
-version = "7.1.1"
+version = "7.1.2"
 dependencies = [
  "merde_core",
  "merde_loggingserializer",
@@ -374,7 +374,7 @@ dependencies = [
 
 [[package]]
 name = "merde_time"
-version = "4.0.17"
+version = "4.0.18"
 dependencies = [
  "merde_core",
  "merde_json",
@@ -383,7 +383,7 @@ dependencies = [
 
 [[package]]
 name = "merde_yaml"
-version = "7.1.1"
+version = "7.1.2"
 dependencies = [
  "merde_core",
  "yaml-rust2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -317,7 +317,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "merde"
-version = "6.2.2"
+version = "8.0.0"
 dependencies = [
  "ahash",
  "merde_core",
@@ -344,7 +344,7 @@ dependencies = [
 
 [[package]]
 name = "merde_json"
-version = "7.0.0"
+version = "8.0.0"
 dependencies = [
  "itoa",
  "lexical-parse-float",
@@ -358,14 +358,14 @@ dependencies = [
 
 [[package]]
 name = "merde_loggingserializer"
-version = "0.1.0"
+version = "8.0.0"
 dependencies = [
  "merde_core",
 ]
 
 [[package]]
 name = "merde_msgpack"
-version = "7.1.2"
+version = "8.0.0"
 dependencies = [
  "merde_core",
  "merde_loggingserializer",
@@ -374,7 +374,7 @@ dependencies = [
 
 [[package]]
 name = "merde_time"
-version = "4.0.18"
+version = "8.0.0"
 dependencies = [
  "merde_core",
  "merde_json",
@@ -383,7 +383,7 @@ dependencies = [
 
 [[package]]
 name = "merde_yaml"
-version = "7.1.2"
+version = "8.0.0"
 dependencies = [
  "merde_core",
  "yaml-rust2",

--- a/merde/CHANGELOG.md
+++ b/merde/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [6.2.2](https://github.com/bearcove/merde/compare/merde-v6.2.1...merde-v6.2.2) - 2024-11-04
+## [8.0.0](https://github.com/bearcove/merde/compare/merde-v6.2.1...merde-v8.0.0) - 2024-11-04
 
 ### Other
 

--- a/merde/CHANGELOG.md
+++ b/merde/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.2.2](https://github.com/bearcove/merde/compare/merde-v6.2.1...merde-v6.2.2) - 2024-11-04
+
+### Other
+
+- Make compact_str / compact_bytes non-optional
+- Introduce Serialize trait
+- Don't allow trivial UB via FieldSlot in safe code
+- I made miri sad
+- Add deserializer opinions, cf. [#89](https://github.com/bearcove/merde/pull/89)
+- woops wrong examples
+- Actually query the stack size, don't hardcode anything
+- The trick actually works
+- Add surprise example
+
 ## [6.2.1](https://github.com/bearcove/merde/compare/merde-v6.2.0...merde-v6.2.1) - 2024-10-07
 
 ### Fixed

--- a/merde/Cargo.toml
+++ b/merde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "merde"
-version = "6.2.1"
+version = "6.2.2"
 edition = "2021"
 authors = ["Amos Wenger <amos@bearcove.net>"]
 description = "Serialize and deserialize with declarative macros"
@@ -56,11 +56,11 @@ path = "examples/opinions.rs"
 required-features = ["json"]
 
 [dependencies]
-merde_core = { version = "7.0.0", path = "../merde_core", optional = true }
-merde_json = { version = "6.2.1", path = "../merde_json", optional = true }
-merde_yaml = { version = "7.1.1", path = "../merde_yaml", optional = true }
-merde_msgpack = { version = "7.1.1", path = "../merde_msgpack", optional = true }
-merde_time = { version = "4.0.17", path = "../merde_time", optional = true, features = [
+merde_core = { version = "8.0.0", path = "../merde_core", optional = true }
+merde_json = { version = "7.0.0", path = "../merde_json", optional = true }
+merde_yaml = { version = "7.1.2", path = "../merde_yaml", optional = true }
+merde_msgpack = { version = "7.1.2", path = "../merde_msgpack", optional = true }
+merde_time = { version = "4.0.18", path = "../merde_time", optional = true, features = [
     "merde",
     "deserialize",
 ] }

--- a/merde/Cargo.toml
+++ b/merde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "merde"
-version = "6.2.2"
+version = "8.0.0"
 edition = "2021"
 authors = ["Amos Wenger <amos@bearcove.net>"]
 description = "Serialize and deserialize with declarative macros"
@@ -57,10 +57,10 @@ required-features = ["json"]
 
 [dependencies]
 merde_core = { version = "8.0.0", path = "../merde_core", optional = true }
-merde_json = { version = "7.0.0", path = "../merde_json", optional = true }
-merde_yaml = { version = "7.1.2", path = "../merde_yaml", optional = true }
-merde_msgpack = { version = "7.1.2", path = "../merde_msgpack", optional = true }
-merde_time = { version = "4.0.18", path = "../merde_time", optional = true, features = [
+merde_json = { version = "8.0.0", path = "../merde_json", optional = true }
+merde_yaml = { version = "8.0.0", path = "../merde_yaml", optional = true }
+merde_msgpack = { version = "8.0.0", path = "../merde_msgpack", optional = true }
+merde_time = { version = "8.0.0", path = "../merde_time", optional = true, features = [
     "merde",
     "deserialize",
 ] }

--- a/merde_core/CHANGELOG.md
+++ b/merde_core/CHANGELOG.md
@@ -6,6 +6,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.0.0](https://github.com/bearcove/merde/compare/merde_core-v7.0.0...merde_core-v8.0.0) - 2024-11-04
+
+### Added
+
+- Impl WithLifetime for Value (woops)
+
+### Other
+
+- Make compact_str / compact_bytes non-optional
+- Introduce Serialize trait
+- As pointed out, FieldSlot must be invariant
+- We did ask miri
+- More tests around FieldSlot ([#101](https://github.com/bearcove/merde/pull/101))
+- Don't allow trivial UB via FieldSlot in safe code
+- I made miri unsad
+- I made miri sad
+- Add deserializer opinions, cf. [#89](https://github.com/bearcove/merde/pull/89)
+- Introduce deserialization opinions
+- macOS fixes
+- Fix infinite stack linux support
+- Oh yeah our MSRV is 1.75 because AFIT
+- fine let's not make msrv rust 1.82
+- Actually query the stack size, don't hardcode anything
+- Comments--
+- The trick actually works
+- Committing before something bad happens
+- Start the trick
+- Deserialize borrowed variants of cowstr
+
 ## [7.0.0](https://github.com/bearcove/merde/compare/merde_core-v6.1.0...merde_core-v7.0.0) - 2024-10-06
 
 ### Added

--- a/merde_core/Cargo.toml
+++ b/merde_core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "merde_core"
-version = "7.0.0"
+version = "8.0.0"
 authors = ["Amos Wenger <amos@bearcove.net>"]
 description = "Base types for merde"
 license = "Apache-2.0 OR MIT"

--- a/merde_json/CHANGELOG.md
+++ b/merde_json/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [7.0.0](https://github.com/bearcove/merde/compare/merde_json-v6.2.1...merde_json-v7.0.0) - 2024-11-04
+## [8.0.0](https://github.com/bearcove/merde/compare/merde_json-v6.2.1...merde_json-v8.0.0) - 2024-11-04
 
 ### Other
 

--- a/merde_json/CHANGELOG.md
+++ b/merde_json/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.0.0](https://github.com/bearcove/merde/compare/merde_json-v6.2.1...merde_json-v7.0.0) - 2024-11-04
+
+### Other
+
+- Introduce Serialize trait
+
 ## [6.2.1](https://github.com/bearcove/merde/compare/merde_json-v6.2.0...merde_json-v6.2.1) - 2024-10-07
 
 ### Fixed

--- a/merde_json/Cargo.toml
+++ b/merde_json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "merde_json"
-version = "6.2.1"
+version = "7.0.0"
 edition = "2021"
 authors = ["Amos Wenger <amos@bearcove.net>"]
 description = "JSON serialization and deserialization for merde, via jiter"
@@ -13,7 +13,7 @@ categories = ["encoding", "parser-implementations"]
 [dependencies]
 itoa = "1.0.11"
 lexical-parse-float = { version = "0.8.5", features = ["format"] }
-merde_core = { version = "7.0.0", path = "../merde_core" }
+merde_core = { version = "8.0.0", path = "../merde_core" }
 num-bigint = { version = "0.4.6", optional = true }
 num-traits = { version = "0.2.19", optional = true }
 ryu = "1.0.18"

--- a/merde_json/Cargo.toml
+++ b/merde_json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "merde_json"
-version = "7.0.0"
+version = "8.0.0"
 edition = "2021"
 authors = ["Amos Wenger <amos@bearcove.net>"]
 description = "JSON serialization and deserialization for merde, via jiter"

--- a/merde_loggingserializer/Cargo.toml
+++ b/merde_loggingserializer/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2021"
 publish = false
 
 [dependencies]
-merde_core = { version = "7.0.0", path = "../merde_core" }
+merde_core = { version = "8.0.0", path = "../merde_core" }

--- a/merde_loggingserializer/Cargo.toml
+++ b/merde_loggingserializer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "merde_loggingserializer"
-version = "0.1.0"
+version = "8.0.0"
 edition = "2021"
 publish = false
 

--- a/merde_msgpack/CHANGELOG.md
+++ b/merde_msgpack/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.1.2](https://github.com/bearcove/merde/compare/merde_msgpack-v7.1.1...merde_msgpack-v7.1.2) - 2024-11-04
+
+### Other
+
+- Introduce Serialize trait
+
 ## [7.1.1](https://github.com/bearcove/merde/compare/merde_msgpack-v7.1.0...merde_msgpack-v7.1.1) - 2024-10-07
 
 ### Fixed

--- a/merde_msgpack/CHANGELOG.md
+++ b/merde_msgpack/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [7.1.2](https://github.com/bearcove/merde/compare/merde_msgpack-v7.1.1...merde_msgpack-v7.1.2) - 2024-11-04
+## [8.0.0](https://github.com/bearcove/merde/compare/merde_msgpack-v7.1.1...merde_msgpack-v8.0.0) - 2024-11-04
 
 ### Other
 

--- a/merde_msgpack/Cargo.toml
+++ b/merde_msgpack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "merde_msgpack"
-version = "7.1.1"
+version = "7.1.2"
 edition = "2021"
 authors = ["Amos Wenger <amos@bearcove.net>"]
 description = "msgpack serizliation/deserialization for merde"
@@ -11,7 +11,7 @@ keywords = ["msgpack", "messagepack", "serialization", "deserialization"]
 categories = ["encoding", "parser-implementations"]
 
 [dependencies]
-merde_core = { version = "7.0.0", path = "../merde_core" }
+merde_core = { version = "8.0.0", path = "../merde_core" }
 rmp = "0.8.14"
 
 [dev-dependencies]

--- a/merde_msgpack/Cargo.toml
+++ b/merde_msgpack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "merde_msgpack"
-version = "7.1.2"
+version = "8.0.0"
 edition = "2021"
 authors = ["Amos Wenger <amos@bearcove.net>"]
 description = "msgpack serizliation/deserialization for merde"

--- a/merde_time/CHANGELOG.md
+++ b/merde_time/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [4.0.18](https://github.com/bearcove/merde/compare/merde_time-v4.0.17...merde_time-v4.0.18) - 2024-11-04
+## [8.0.0](https://github.com/bearcove/merde/compare/merde_time-v4.0.17...merde_time-v8.0.0) - 2024-11-04
 
 ### Other
 

--- a/merde_time/CHANGELOG.md
+++ b/merde_time/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.18](https://github.com/bearcove/merde/compare/merde_time-v4.0.17...merde_time-v4.0.18) - 2024-11-04
+
+### Other
+
+- Introduce Serialize trait
+- Also run tests on macOS ([#99](https://github.com/bearcove/merde/pull/99))
+
 ## [4.0.17](https://github.com/bearcove/merde/compare/merde_time-v4.0.16...merde_time-v4.0.17) - 2024-10-07
 
 ### Other

--- a/merde_time/Cargo.toml
+++ b/merde_time/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "merde_time"
-version = "4.0.17"
+version = "4.0.18"
 authors = ["Amos Wenger <amos@bearcove.net>"]
 description = "Wrapper date-time types for merde"
 license = "Apache-2.0 OR MIT"
@@ -11,8 +11,8 @@ keywords = ["merde", "serialization", "deserialization"]
 categories = ["encoding", "parser-implementations"]
 
 [dependencies]
-merde_core = { version = "7.0.0", path = "../merde_core", optional = true }
-merde_json = { version = "6.2.1", path = "../merde_json", optional = true }
+merde_core = { version = "8.0.0", path = "../merde_core", optional = true }
+merde_json = { version = "7.0.0", path = "../merde_json", optional = true }
 time = "0.3.36"
 
 [dev-dependencies]

--- a/merde_time/Cargo.toml
+++ b/merde_time/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "merde_time"
-version = "4.0.18"
+version = "8.0.0"
 authors = ["Amos Wenger <amos@bearcove.net>"]
 description = "Wrapper date-time types for merde"
 license = "Apache-2.0 OR MIT"
@@ -12,7 +12,7 @@ categories = ["encoding", "parser-implementations"]
 
 [dependencies]
 merde_core = { version = "8.0.0", path = "../merde_core", optional = true }
-merde_json = { version = "7.0.0", path = "../merde_json", optional = true }
+merde_json = { version = "8.0.0", path = "../merde_json", optional = true }
 time = "0.3.36"
 
 [dev-dependencies]

--- a/merde_yaml/CHANGELOG.md
+++ b/merde_yaml/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [7.1.2](https://github.com/bearcove/merde/compare/merde_yaml-v7.1.1...merde_yaml-v7.1.2) - 2024-11-04
+## [8.0.0](https://github.com/bearcove/merde/compare/merde_yaml-v7.1.1...merde_yaml-v8.0.0) - 2024-11-04
 
 ### Other
 

--- a/merde_yaml/CHANGELOG.md
+++ b/merde_yaml/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.1.2](https://github.com/bearcove/merde/compare/merde_yaml-v7.1.1...merde_yaml-v7.1.2) - 2024-11-04
+
+### Other
+
+- Introduce Serialize trait
+
 ## [7.1.1](https://github.com/bearcove/merde/compare/merde_yaml-v7.1.0...merde_yaml-v7.1.1) - 2024-10-06
 
 ### Other

--- a/merde_yaml/Cargo.toml
+++ b/merde_yaml/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "merde_yaml"
-version = "7.1.1"
+version = "7.1.2"
 edition = "2021"
 authors = ["Amos Wenger <amos@bearcove.net>"]
 description = "YAML deserialization for merde"
@@ -11,5 +11,5 @@ keywords = ["yaml", "serialization", "deserialization"]
 categories = ["encoding", "parser-implementations"]
 
 [dependencies]
-merde_core = { version = "7.0.0", path = "../merde_core" }
+merde_core = { version = "8.0.0", path = "../merde_core" }
 yaml-rust2 = { version = "0.8.1", default-features = false }

--- a/merde_yaml/Cargo.toml
+++ b/merde_yaml/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "merde_yaml"
-version = "7.1.2"
+version = "8.0.0"
 edition = "2021"
 authors = ["Amos Wenger <amos@bearcove.net>"]
 description = "YAML deserialization for merde"


### PR DESCRIPTION
## 🤖 New release
* `merde`: 6.2.1 -> 6.2.2 (✓ API compatible changes)
* `merde_core`: 7.0.0 -> 8.0.0 (⚠️ API breaking changes)
* `merde_json`: 6.2.1 -> 7.0.0 (⚠️ API breaking changes)
* `merde_msgpack`: 7.1.1 -> 7.1.2 (✓ API compatible changes)
* `merde_time`: 4.0.17 -> 4.0.18 (✓ API compatible changes)
* `merde_yaml`: 7.1.1 -> 7.1.2 (✓ API compatible changes)

### ⚠️ `merde_core` breaking changes

```
--- failure enum_unit_variant_changed_kind: An enum unit variant changed kind ---

Description:
A public enum's exhaustive unit variant has changed to a different kind of enum variant, breaking possible instantiations and patterns.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/enum_unit_variant_changed_kind.ron

Failed in:
  variant Event::MapStart in /tmp/.tmppvN4I8/merde/merde_core/src/event.rs:14

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/enum_variant_added.ron

Failed in:
  variant Event:F64 in /tmp/.tmppvN4I8/merde/merde_core/src/event.rs:9

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/enum_variant_missing.ron

Failed in:
  variant Event::Float, previously in file /tmp/.tmp9iI9hl/merde_core/src/deserialize.rs:16
```

### ⚠️ `merde_json` breaking changes

```
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/enum_variant_added.ron

Failed in:
  variant MerdeJsonError:Io in /tmp/.tmppvN4I8/merde/merde_json/src/lib.rs:260
  variant MerdeJsonError:JsonDoesNotSupportBytes in /tmp/.tmppvN4I8/merde/merde_json/src/lib.rs:263

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/inherent_method_missing.ron

Failed in:
  JsonSerializer::from_vec, previously in file /tmp/.tmp9iI9hl/merde_json/src/lib.rs:30
  JsonSerializer::write_null, previously in file /tmp/.tmp9iI9hl/merde_json/src/lib.rs:40
  JsonSerializer::write_bool, previously in file /tmp/.tmp9iI9hl/merde_json/src/lib.rs:45
  JsonSerializer::write_i64, previously in file /tmp/.tmp9iI9hl/merde_json/src/lib.rs:52
  JsonSerializer::write_f64, previously in file /tmp/.tmp9iI9hl/merde_json/src/lib.rs:57
  JsonSerializer::write_str, previously in file /tmp/.tmp9iI9hl/merde_json/src/lib.rs:62
  JsonSerializer::write_obj, previously in file /tmp/.tmp9iI9hl/merde_json/src/lib.rs:83
  JsonSerializer::write_arr, previously in file /tmp/.tmp9iI9hl/merde_json/src/lib.rs:94
  JsonSerializer::into_inner, previously in file /tmp/.tmp9iI9hl/merde_json/src/lib.rs:103
  JsonSerializer::as_mut_vec, previously in file /tmp/.tmp9iI9hl/merde_json/src/lib.rs:110

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/method_parameter_count_changed.ron

Failed in:
  merde_json::JsonSerializer::new now takes 1 parameters instead of 0, in /tmp/.tmppvN4I8/merde/merde_json/src/lib.rs:193

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/struct_missing.ron

Failed in:
  struct merde_json::ObjectGuard, previously in file /tmp/.tmp9iI9hl/merde_json/src/lib.rs:116
  struct merde_json::ArrayGuard, previously in file /tmp/.tmp9iI9hl/merde_json/src/lib.rs:144

--- failure trait_added_supertrait: non-sealed trait added new supertraits ---

Description:
A non-sealed trait added one or more supertraits, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#generic-bounds-tighten
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/trait_added_supertrait.ron

Failed in:
  trait merde_json::JsonSerialize gained Serialize in file /tmp/.tmppvN4I8/merde/merde_json/src/lib.rs:221
  trait merde_json::JsonSerialize gained Sized in file /tmp/.tmppvN4I8/merde/merde_json/src/lib.rs:221

--- failure trait_method_missing: pub trait method removed or renamed ---

Description:
A trait method is no longer callable, and may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#major-any-change-to-trait-item-signatures
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/trait_method_missing.ron

Failed in:
  method json_serialize of trait JsonSerialize, previously in file /tmp/.tmp9iI9hl/merde_json/src/lib.rs:186

--- failure trait_no_longer_object_safe: trait no longer object safe ---

Description:
Trait is no longer object safe, which breaks `dyn Trait` usage.
        ref: https://doc.rust-lang.org/stable/reference/items/traits.html#object-safety
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/trait_no_longer_object_safe.ron

Failed in:
  trait JsonSerialize in file /tmp/.tmppvN4I8/merde/merde_json/src/lib.rs:221
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `merde`
<blockquote>

## [6.2.2](https://github.com/bearcove/merde/compare/merde-v6.2.1...merde-v6.2.2) - 2024-11-04

### Other

- Make compact_str / compact_bytes non-optional
- Introduce Serialize trait
- Don't allow trivial UB via FieldSlot in safe code
- I made miri sad
- Add deserializer opinions, cf. [#89](https://github.com/bearcove/merde/pull/89)
- woops wrong examples
- Actually query the stack size, don't hardcode anything
- The trick actually works
- Add surprise example
</blockquote>

## `merde_core`
<blockquote>

## [8.0.0](https://github.com/bearcove/merde/compare/merde_core-v7.0.0...merde_core-v8.0.0) - 2024-11-04

### Added

- Impl WithLifetime for Value (woops)

### Other

- Make compact_str / compact_bytes non-optional
- Introduce Serialize trait
- As pointed out, FieldSlot must be invariant
- We did ask miri
- More tests around FieldSlot ([#101](https://github.com/bearcove/merde/pull/101))
- Don't allow trivial UB via FieldSlot in safe code
- I made miri unsad
- I made miri sad
- Add deserializer opinions, cf. [#89](https://github.com/bearcove/merde/pull/89)
- Introduce deserialization opinions
- macOS fixes
- Fix infinite stack linux support
- Oh yeah our MSRV is 1.75 because AFIT
- fine let's not make msrv rust 1.82
- Actually query the stack size, don't hardcode anything
- Comments--
- The trick actually works
- Committing before something bad happens
- Start the trick
- Deserialize borrowed variants of cowstr
</blockquote>

## `merde_json`
<blockquote>

## [7.0.0](https://github.com/bearcove/merde/compare/merde_json-v6.2.1...merde_json-v7.0.0) - 2024-11-04

### Other

- Introduce Serialize trait
</blockquote>

## `merde_msgpack`
<blockquote>

## [7.1.2](https://github.com/bearcove/merde/compare/merde_msgpack-v7.1.1...merde_msgpack-v7.1.2) - 2024-11-04

### Other

- Introduce Serialize trait
</blockquote>

## `merde_time`
<blockquote>

## [4.0.18](https://github.com/bearcove/merde/compare/merde_time-v4.0.17...merde_time-v4.0.18) - 2024-11-04

### Other

- Introduce Serialize trait
- Also run tests on macOS ([#99](https://github.com/bearcove/merde/pull/99))
</blockquote>

## `merde_yaml`
<blockquote>

## [7.1.2](https://github.com/bearcove/merde/compare/merde_yaml-v7.1.1...merde_yaml-v7.1.2) - 2024-11-04

### Other

- Introduce Serialize trait
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).