### PR TITLE
Don't rely on `type_name` being unique

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -28,3 +28,4 @@ check:
 
 miri:
     cargo +nightly miri run --example opinions -F json
+    cargo +nightly miri test -p merde_core

--- a/merde_core/src/deserialize/tests.rs
+++ b/merde_core/src/deserialize/tests.rs
@@ -1,0 +1,35 @@
+use super::FieldSlot;
+
+#[test]
+fn test_fieldslot_no_assign() {
+    let mut option: Option<i32> = None;
+
+    {
+        let slot = FieldSlot::new(&mut option);
+        // let it drop
+        let _ = slot;
+    }
+
+    assert!(option.is_none());
+}
+
+#[test]
+fn test_fieldslot_with_assign() {
+    let mut option: Option<i32> = None;
+
+    {
+        let slot = FieldSlot::new(&mut option);
+        slot.fill::<i32>(42);
+    }
+
+    assert_eq!(option, Some(42));
+}
+
+#[test]
+#[should_panic(expected = "tried to assign")]
+fn test_fieldslot_with_assign_mismatched_type() {
+    let mut option: Option<String> = None;
+
+    let slot = FieldSlot::new(&mut option);
+    slot.fill::<i32>(42);
+}


### PR DESCRIPTION
Rely on typeid instead.

Take a trick from <https://github.com/dtolnay/typeid> to be able to get a typeid from non-static types: there's only ever one lifetime involved, so it should be cool.