### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -317,7 +317,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "merde"
-version = "8.1.1"
+version = "8.1.2"
 dependencies = [
  "ahash",
  "merde_core",
@@ -374,7 +374,7 @@ dependencies = [
 
 [[package]]
 name = "merde_time"
-version = "8.0.1"
+version = "8.0.2"
 dependencies = [
  "merde_core",
  "merde_json",

--- a/merde/CHANGELOG.md
+++ b/merde/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.1.2](https://github.com/bearcove/merde/compare/merde-v8.1.1...merde-v8.1.2) - 2024-11-20
+
+### Other
+
+- Fix deser/ser impls in merde_time after phasing out JsonSerialize trait
+
 ## [8.1.1](https://github.com/bearcove/merde/compare/merde-v8.1.0...merde-v8.1.1) - 2024-11-20
 
 ### Other

--- a/merde/Cargo.toml
+++ b/merde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "merde"
-version = "8.1.1"
+version = "8.1.2"
 edition = "2021"
 authors = ["Amos Wenger <amos@bearcove.net>"]
 description = "Serialize and deserialize with declarative macros"
@@ -60,7 +60,7 @@ merde_core = { version = "8.1.0", path = "../merde_core", optional = true }
 merde_json = { version = "8.0.1", path = "../merde_json", optional = true }
 merde_yaml = { version = "8.0.1", path = "../merde_yaml", optional = true }
 merde_msgpack = { version = "8.0.1", path = "../merde_msgpack", optional = true }
-merde_time = { version = "8.0.1", path = "../merde_time", optional = true, features = [
+merde_time = { version = "8.0.2", path = "../merde_time", optional = true, features = [
     "merde",
     "serialize",
     "deserialize",

--- a/merde_time/CHANGELOG.md
+++ b/merde_time/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.0.2](https://github.com/bearcove/merde/compare/merde_time-v8.0.1...merde_time-v8.0.2) - 2024-11-20
+
+### Other
+
+- Fix deser/ser impls in merde_time after phasing out JsonSerialize trait
+
 ## [8.0.1](https://github.com/bearcove/merde/compare/merde_time-v8.0.0...merde_time-v8.0.1) - 2024-11-20
 
 ### Other

--- a/merde_time/Cargo.toml
+++ b/merde_time/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "merde_time"
-version = "8.0.1"
+version = "8.0.2"
 authors = ["Amos Wenger <amos@bearcove.net>"]
 description = "Wrapper date-time types for merde"
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
## 🤖 New release
* `merde`: 8.1.1 -> 8.1.2 (✓ API compatible changes)
* `merde_time`: 8.0.1 -> 8.0.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `merde`
<blockquote>

## [8.1.2](https://github.com/bearcove/merde/compare/merde-v8.1.1...merde-v8.1.2) - 2024-11-20

### Other

- Fix deser/ser impls in merde_time after phasing out JsonSerialize trait
</blockquote>

## `merde_time`
<blockquote>

## [8.0.2](https://github.com/bearcove/merde/compare/merde_time-v8.0.1...merde_time-v8.0.2) - 2024-11-20

### Other

- Fix deser/ser impls in merde_time after phasing out JsonSerialize trait
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).