### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -317,7 +317,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "merde"
-version = "8.1.2"
+version = "8.1.3"
 dependencies = [
  "ahash",
  "merde_core",
@@ -329,7 +329,7 @@ dependencies = [
 
 [[package]]
 name = "merde_core"
-version = "8.1.0"
+version = "8.1.1"
 dependencies = [
  "compact_bytes",
  "compact_str",
@@ -344,7 +344,7 @@ dependencies = [
 
 [[package]]
 name = "merde_json"
-version = "8.0.1"
+version = "8.0.2"
 dependencies = [
  "itoa",
  "lexical-parse-float",
@@ -365,7 +365,7 @@ dependencies = [
 
 [[package]]
 name = "merde_msgpack"
-version = "8.0.1"
+version = "8.0.2"
 dependencies = [
  "merde_core",
  "merde_loggingserializer",
@@ -374,7 +374,7 @@ dependencies = [
 
 [[package]]
 name = "merde_time"
-version = "8.0.2"
+version = "8.0.3"
 dependencies = [
  "merde_core",
  "merde_json",
@@ -383,7 +383,7 @@ dependencies = [
 
 [[package]]
 name = "merde_yaml"
-version = "8.0.1"
+version = "8.0.2"
 dependencies = [
  "merde_core",
  "yaml-rust2",

--- a/merde/CHANGELOG.md
+++ b/merde/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.1.3](https://github.com/bearcove/merde/compare/merde-v8.1.2...merde-v8.1.3) - 2024-11-24
+
+### Other
+
+- updated the following local packages: merde_core
+
 ## [8.1.2](https://github.com/bearcove/merde/compare/merde-v8.1.1...merde-v8.1.2) - 2024-11-20
 
 ### Other

--- a/merde/Cargo.toml
+++ b/merde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "merde"
-version = "8.1.2"
+version = "8.1.3"
 edition = "2021"
 authors = ["Amos Wenger <amos@bearcove.net>"]
 description = "Serialize and deserialize with declarative macros"
@@ -56,11 +56,11 @@ path = "examples/opinions.rs"
 required-features = ["json"]
 
 [dependencies]
-merde_core = { version = "8.1.0", path = "../merde_core", optional = true }
-merde_json = { version = "8.0.1", path = "../merde_json", optional = true }
-merde_yaml = { version = "8.0.1", path = "../merde_yaml", optional = true }
-merde_msgpack = { version = "8.0.1", path = "../merde_msgpack", optional = true }
-merde_time = { version = "8.0.2", path = "../merde_time", optional = true, features = [
+merde_core = { version = "8.1.1", path = "../merde_core", optional = true }
+merde_json = { version = "8.0.2", path = "../merde_json", optional = true }
+merde_yaml = { version = "8.0.2", path = "../merde_yaml", optional = true }
+merde_msgpack = { version = "8.0.2", path = "../merde_msgpack", optional = true }
+merde_time = { version = "8.0.3", path = "../merde_time", optional = true, features = [
     "merde",
     "serialize",
     "deserialize",

--- a/merde_core/CHANGELOG.md
+++ b/merde_core/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.1.1](https://github.com/bearcove/merde/compare/merde_core-v8.1.0...merde_core-v8.1.1) - 2024-11-24
+
+### Other
+
+- impl WIthLifetime for Option<T>
+
 ## [8.1.0](https://github.com/bearcove/merde/compare/merde_core-v8.0.0...merde_core-v8.1.0) - 2024-11-20
 
 ### Added

--- a/merde_core/Cargo.toml
+++ b/merde_core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "merde_core"
-version = "8.1.0"
+version = "8.1.1"
 authors = ["Amos Wenger <amos@bearcove.net>"]
 description = "Base types for merde"
 license = "Apache-2.0 OR MIT"

--- a/merde_json/CHANGELOG.md
+++ b/merde_json/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.0.2](https://github.com/bearcove/merde/compare/merde_json-v8.0.1...merde_json-v8.0.2) - 2024-11-24
+
+### Other
+
+- updated the following local packages: merde_core
+
 ## [8.0.1](https://github.com/bearcove/merde/compare/merde_json-v8.0.0...merde_json-v8.0.1) - 2024-11-20
 
 ### Other

--- a/merde_json/Cargo.toml
+++ b/merde_json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "merde_json"
-version = "8.0.1"
+version = "8.0.2"
 edition = "2021"
 authors = ["Amos Wenger <amos@bearcove.net>"]
 description = "JSON serialization and deserialization for merde, via jiter"
@@ -13,7 +13,7 @@ categories = ["encoding", "parser-implementations"]
 [dependencies]
 itoa = "1.0.11"
 lexical-parse-float = { version = "0.8.5", features = ["format"] }
-merde_core = { version = "8.1.0", path = "../merde_core" }
+merde_core = { version = "8.1.1", path = "../merde_core" }
 num-bigint = { version = "0.4.6", optional = true }
 num-traits = { version = "0.2.19", optional = true }
 ryu = "1.0.18"

--- a/merde_loggingserializer/Cargo.toml
+++ b/merde_loggingserializer/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2021"
 publish = false
 
 [dependencies]
-merde_core = { version = "8.1.0", path = "../merde_core" }
+merde_core = { version = "8.1.1", path = "../merde_core" }

--- a/merde_msgpack/CHANGELOG.md
+++ b/merde_msgpack/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.0.2](https://github.com/bearcove/merde/compare/merde_msgpack-v8.0.1...merde_msgpack-v8.0.2) - 2024-11-24
+
+### Other
+
+- updated the following local packages: merde_core
+
 ## [8.0.1](https://github.com/bearcove/merde/compare/merde_msgpack-v8.0.0...merde_msgpack-v8.0.1) - 2024-11-20
 
 ### Other

--- a/merde_msgpack/Cargo.toml
+++ b/merde_msgpack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "merde_msgpack"
-version = "8.0.1"
+version = "8.0.2"
 edition = "2021"
 authors = ["Amos Wenger <amos@bearcove.net>"]
 description = "msgpack serizliation/deserialization for merde"
@@ -11,7 +11,7 @@ keywords = ["msgpack", "messagepack", "serialization", "deserialization"]
 categories = ["encoding", "parser-implementations"]
 
 [dependencies]
-merde_core = { version = "8.1.0", path = "../merde_core" }
+merde_core = { version = "8.1.1", path = "../merde_core" }
 rmp = "0.8.14"
 
 [dev-dependencies]

--- a/merde_time/CHANGELOG.md
+++ b/merde_time/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.0.3](https://github.com/bearcove/merde/compare/merde_time-v8.0.2...merde_time-v8.0.3) - 2024-11-24
+
+### Other
+
+- updated the following local packages: merde_core
+
 ## [8.0.2](https://github.com/bearcove/merde/compare/merde_time-v8.0.1...merde_time-v8.0.2) - 2024-11-20
 
 ### Other

--- a/merde_time/Cargo.toml
+++ b/merde_time/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "merde_time"
-version = "8.0.2"
+version = "8.0.3"
 authors = ["Amos Wenger <amos@bearcove.net>"]
 description = "Wrapper date-time types for merde"
 license = "Apache-2.0 OR MIT"
@@ -11,8 +11,8 @@ keywords = ["merde", "serialization", "deserialization"]
 categories = ["encoding", "parser-implementations"]
 
 [dependencies]
-merde_core = { version = "8.1.0", path = "../merde_core", optional = true }
-merde_json = { version = "8.0.1", path = "../merde_json", optional = true }
+merde_core = { version = "8.1.1", path = "../merde_core", optional = true }
+merde_json = { version = "8.0.2", path = "../merde_json", optional = true }
 time = "0.3.36"
 
 [dev-dependencies]

--- a/merde_yaml/CHANGELOG.md
+++ b/merde_yaml/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.0.2](https://github.com/bearcove/merde/compare/merde_yaml-v8.0.1...merde_yaml-v8.0.2) - 2024-11-24
+
+### Other
+
+- updated the following local packages: merde_core
+
 ## [8.0.1](https://github.com/bearcove/merde/compare/merde_yaml-v8.0.0...merde_yaml-v8.0.1) - 2024-11-20
 
 ### Other

--- a/merde_yaml/Cargo.toml
+++ b/merde_yaml/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "merde_yaml"
-version = "8.0.1"
+version = "8.0.2"
 edition = "2021"
 authors = ["Amos Wenger <amos@bearcove.net>"]
 description = "YAML deserialization for merde"
@@ -11,5 +11,5 @@ keywords = ["yaml", "serialization", "deserialization"]
 categories = ["encoding", "parser-implementations"]
 
 [dependencies]
-merde_core = { version = "8.1.0", path = "../merde_core" }
+merde_core = { version = "8.1.1", path = "../merde_core" }
 yaml-rust2 = { version = "0.8.1", default-features = false }


### PR DESCRIPTION
## 🤖 New release
* `merde_core`: 8.1.0 -> 8.1.1 (✓ API compatible changes)
* `merde`: 8.1.2 -> 8.1.3
* `merde_json`: 8.0.1 -> 8.0.2
* `merde_msgpack`: 8.0.1 -> 8.0.2
* `merde_time`: 8.0.2 -> 8.0.3
* `merde_yaml`: 8.0.1 -> 8.0.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `merde_core`
<blockquote>

## [8.1.1](https://github.com/bearcove/merde/compare/merde_core-v8.1.0...merde_core-v8.1.1) - 2024-11-24

### Other

- impl WIthLifetime for Option<T>
</blockquote>

## `merde`
<blockquote>

## [8.1.3](https://github.com/bearcove/merde/compare/merde-v8.1.2...merde-v8.1.3) - 2024-11-24

### Other

- updated the following local packages: merde_core
</blockquote>

## `merde_json`
<blockquote>

## [8.0.2](https://github.com/bearcove/merde/compare/merde_json-v8.0.1...merde_json-v8.0.2) - 2024-11-24

### Other

- updated the following local packages: merde_core
</blockquote>

## `merde_msgpack`
<blockquote>

## [8.0.2](https://github.com/bearcove/merde/compare/merde_msgpack-v8.0.1...merde_msgpack-v8.0.2) - 2024-11-24

### Other

- updated the following local packages: merde_core
</blockquote>

## `merde_time`
<blockquote>

## [8.0.3](https://github.com/bearcove/merde/compare/merde_time-v8.0.2...merde_time-v8.0.3) - 2024-11-24

### Other

- updated the following local packages: merde_core
</blockquote>

## `merde_yaml`
<blockquote>

## [8.0.2](https://github.com/bearcove/merde/compare/merde_yaml-v8.0.1...merde_yaml-v8.0.2) - 2024-11-24

### Other

- updated the following local packages: merde_core
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).