### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -317,7 +317,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "merde"
-version = "8.1.3"
+version = "8.1.4"
 dependencies = [
  "ahash",
  "merde_core",
@@ -328,7 +328,7 @@ dependencies = [
 
 [[package]]
 name = "merde_core"
-version = "8.1.1"
+version = "9.0.0"
 dependencies = [
  "compact_bytes",
  "compact_str",
@@ -343,7 +343,7 @@ dependencies = [
 
 [[package]]
 name = "merde_json"
-version = "8.0.2"
+version = "9.0.0"
 dependencies = [
  "itoa",
  "lexical-parse-float",
@@ -362,7 +362,7 @@ dependencies = [
 
 [[package]]
 name = "merde_msgpack"
-version = "8.0.2"
+version = "9.0.0"
 dependencies = [
  "merde_core",
  "merde_loggingserializer",
@@ -371,7 +371,7 @@ dependencies = [
 
 [[package]]
 name = "merde_yaml"
-version = "8.0.2"
+version = "9.0.0"
 dependencies = [
  "merde_core",
  "yaml-rust2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -317,7 +317,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "merde"
-version = "8.1.4"
+version = "9.0.0"
 dependencies = [
  "ahash",
  "merde_core",

--- a/merde/CHANGELOG.md
+++ b/merde/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [8.1.4](https://github.com/bearcove/merde/compare/merde-v8.1.3...merde-v8.1.4) - 2024-11-30
+## [9.0.0](https://github.com/bearcove/merde/compare/merde-v8.1.3...merde-v9.0.0) - 2024-11-30
 
 ### Other
 

--- a/merde/CHANGELOG.md
+++ b/merde/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.1.4](https://github.com/bearcove/merde/compare/merde-v8.1.3...merde-v8.1.4) - 2024-11-30
+
+### Other
+
+- remove async versions of things
+- wip dyn serialize
+- Tests pass
+- no errors left?
+- Fix more warnings and errors
+- More!
+- yay other errors
+- Dwip
+- Remove JsonSerialize trait
+- Expose an async Deserializer interface
+- Make Deserializer::next async
+- Move things around re: absorbing merde_time in merde_core
+- Yus
+
 ## [8.1.3](https://github.com/bearcove/merde/compare/merde-v8.1.2...merde-v8.1.3) - 2024-11-24
 
 ### Other

--- a/merde/Cargo.toml
+++ b/merde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "merde"
-version = "8.1.3"
+version = "8.1.4"
 edition = "2021"
 authors = ["Amos Wenger <amos@bearcove.net>"]
 description = "Serialize and deserialize with declarative macros"
@@ -56,10 +56,10 @@ path = "examples/opinions.rs"
 required-features = ["json"]
 
 [dependencies]
-merde_core = { version = "8.1.1", path = "../merde_core", optional = true }
-merde_json = { version = "8.0.2", path = "../merde_json", optional = true }
-merde_yaml = { version = "8.0.2", path = "../merde_yaml", optional = true }
-merde_msgpack = { version = "8.0.2", path = "../merde_msgpack", optional = true }
+merde_core = { version = "9.0.0", path = "../merde_core", optional = true }
+merde_json = { version = "9.0.0", path = "../merde_json", optional = true }
+merde_yaml = { version = "9.0.0", path = "../merde_yaml", optional = true }
+merde_msgpack = { version = "9.0.0", path = "../merde_msgpack", optional = true }
 ahash = { version = "0.8.11", optional = true }
 
 [features]

--- a/merde/Cargo.toml
+++ b/merde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "merde"
-version = "8.1.4"
+version = "9.0.0"
 edition = "2021"
 authors = ["Amos Wenger <amos@bearcove.net>"]
 description = "Serialize and deserialize with declarative macros"

--- a/merde_core/CHANGELOG.md
+++ b/merde_core/CHANGELOG.md
@@ -6,6 +6,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [9.0.0](https://github.com/bearcove/merde/compare/merde_core-v8.1.1...merde_core-v9.0.0) - 2024-11-30
+
+### Other
+
+- Introduce DynDeserialize
+- Remove workaround for https://github.com/rust-lang/rust/issues/133676
+- Mhh
+- Use DynSerialize in merde_json
+- Introduce DynSerialize
+- Rename serialize_sync to serialize
+- remove async versions of things
+- wip dyn serialize
+- More!
+- yay other errors
+- Dwip
+- lift static requirement
+- mhh lifetimes yes
+- mh
+- well that's hard
+- Expose to_tokio_writer
+- Remove JsonSerialize trait
+- Expose an async Deserializer interface
+- Make Deserializer::next async
+- Move things around re: absorbing merde_time in merde_core
+- Yus
+
 ## [8.1.1](https://github.com/bearcove/merde/compare/merde_core-v8.1.0...merde_core-v8.1.1) - 2024-11-24
 
 ### Other

--- a/merde_core/Cargo.toml
+++ b/merde_core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "merde_core"
-version = "8.1.1"
+version = "9.0.0"
 authors = ["Amos Wenger <amos@bearcove.net>"]
 description = "Base types for merde"
 license = "Apache-2.0 OR MIT"

--- a/merde_json/CHANGELOG.md
+++ b/merde_json/CHANGELOG.md
@@ -6,6 +6,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [9.0.0](https://github.com/bearcove/merde/compare/merde_json-v8.0.2...merde_json-v9.0.0) - 2024-11-30
+
+### Other
+
+- Mhh
+- Use DynSerialize in merde_json
+- Rename serialize_sync to serialize
+- async stuff Does Not Work for now
+- remove async versions of things
+- wip dyn serialize
+- bye bigint
+- Remove unused jiter_lite methods
+- Fix more warnings and errors
+- More!
+- yay other errors
+- Dwip
+- Expose to_tokio_writer
+- Remove JsonSerialize trait
+- Expose an async Deserializer interface
+- Make Deserializer::next async
+- Move things around re: absorbing merde_time in merde_core
+
 ## [8.0.2](https://github.com/bearcove/merde/compare/merde_json-v8.0.1...merde_json-v8.0.2) - 2024-11-24
 
 ### Other

--- a/merde_json/Cargo.toml
+++ b/merde_json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "merde_json"
-version = "8.0.2"
+version = "9.0.0"
 edition = "2021"
 authors = ["Amos Wenger <amos@bearcove.net>"]
 description = "JSON serialization and deserialization for merde, via jiter"
@@ -13,7 +13,7 @@ categories = ["encoding", "parser-implementations"]
 [dependencies]
 itoa = "1.0.11"
 lexical-parse-float = { version = "0.8.5", features = ["format"] }
-merde_core = { version = "8.1.1", path = "../merde_core" }
+merde_core = { version = "9.0.0", path = "../merde_core" }
 ryu = "1.0.18"
 tokio = { version = "1", optional = true, features = ["io-util"] }
 

--- a/merde_loggingserializer/Cargo.toml
+++ b/merde_loggingserializer/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2021"
 publish = false
 
 [dependencies]
-merde_core = { version = "8.1.1", path = "../merde_core" }
+merde_core = { version = "9.0.0", path = "../merde_core" }

--- a/merde_msgpack/CHANGELOG.md
+++ b/merde_msgpack/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [9.0.0](https://github.com/bearcove/merde/compare/merde_msgpack-v8.0.2...merde_msgpack-v9.0.0) - 2024-11-30
+
+### Other
+
+- remove async versions of things
+- More!
+- yay other errors
+- Expose an async Deserializer interface
+- Make Deserializer::next async
+
 ## [8.0.2](https://github.com/bearcove/merde/compare/merde_msgpack-v8.0.1...merde_msgpack-v8.0.2) - 2024-11-24
 
 ### Other

--- a/merde_msgpack/Cargo.toml
+++ b/merde_msgpack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "merde_msgpack"
-version = "8.0.2"
+version = "9.0.0"
 edition = "2021"
 authors = ["Amos Wenger <amos@bearcove.net>"]
 description = "msgpack serizliation/deserialization for merde"
@@ -11,7 +11,7 @@ keywords = ["msgpack", "messagepack", "serialization", "deserialization"]
 categories = ["encoding", "parser-implementations"]
 
 [dependencies]
-merde_core = { version = "8.1.1", path = "../merde_core" }
+merde_core = { version = "9.0.0", path = "../merde_core" }
 rmp = "0.8.14"
 
 [dev-dependencies]

--- a/merde_yaml/CHANGELOG.md
+++ b/merde_yaml/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [9.0.0](https://github.com/bearcove/merde/compare/merde_yaml-v8.0.2...merde_yaml-v9.0.0) - 2024-11-30
+
+### Other
+
+- remove async versions of things
+- More!
+- yay other errors
+- Expose an async Deserializer interface
+- Make Deserializer::next async
+
 ## [8.0.2](https://github.com/bearcove/merde/compare/merde_yaml-v8.0.1...merde_yaml-v8.0.2) - 2024-11-24
 
 ### Other

--- a/merde_yaml/Cargo.toml
+++ b/merde_yaml/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "merde_yaml"
-version = "8.0.2"
+version = "9.0.0"
 edition = "2021"
 authors = ["Amos Wenger <amos@bearcove.net>"]
 description = "YAML deserialization for merde"
@@ -11,5 +11,5 @@ keywords = ["yaml", "serialization", "deserialization"]
 categories = ["encoding", "parser-implementations"]
 
 [dependencies]
-merde_core = { version = "8.1.1", path = "../merde_core" }
+merde_core = { version = "9.0.0", path = "../merde_core" }
 yaml-rust2 = { version = "0.8.1", default-features = false }


### PR DESCRIPTION
## 🤖 New release
* `merde`: 8.1.3 -> 8.1.4 (✓ API compatible changes)
* `merde_core`: 8.1.1 -> 9.0.0 (⚠️ API breaking changes)
* `merde_json`: 8.0.2 -> 9.0.0 (⚠️ API breaking changes)
* `merde_msgpack`: 8.0.2 -> 9.0.0 (⚠️ API breaking changes)
* `merde_yaml`: 8.0.2 -> 9.0.0 (⚠️ API breaking changes)

### ⚠️ `merde_core` breaking changes

```
--- failure enum_struct_variant_field_added: pub enum struct variant field added ---

Description:
An enum's exhaustive struct variant has a new field, which has to be included when constructing or matching on this variant.
        ref: https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/enum_struct_variant_field_added.ron

Failed in:
  field help of variant MerdeError::UnexpectedEvent in /tmp/.tmpThbCt0/merde/merde_core/src/error.rs:85

--- failure trait_added_supertrait: non-sealed trait added new supertraits ---

Description:
A non-sealed trait added one or more supertraits, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#generic-bounds-tighten
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/trait_added_supertrait.ron

Failed in:
  trait merde_core::IntoStatic gained Sized in file /tmp/.tmpThbCt0/merde/merde_core/src/into_static.rs:14
  trait merde_core::DeserializeOwned gained IntoStatic in file /tmp/.tmpThbCt0/merde/merde_core/src/deserialize.rs:246

--- failure trait_method_added: pub trait method added ---

Description:
A non-sealed public trait added a new method without a default implementation, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/trait_method_added.ron

Failed in:
  trait method merde_core::Deserializer::put_back in file /tmp/.tmpThbCt0/merde/merde_core/src/deserialize.rs:21

--- failure trait_method_missing: pub trait method removed or renamed ---

Description:
A trait method is no longer callable, and may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#major-any-change-to-trait-item-signatures
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/trait_method_missing.ron

Failed in:
  method serialize_sync of trait Serializer, previously in file /tmp/.tmp1jLhqH/merde_core/src/serialize.rs:14
  method serialize of trait Serializer, previously in file /tmp/.tmp1jLhqH/merde_core/src/serialize.rs:19
  method deserialize of trait Deserializer, previously in file /tmp/.tmp1jLhqH/merde_core/src/deserialize.rs:37
  method deserialize_owned of trait Deserializer, previously in file /tmp/.tmp1jLhqH/merde_core/src/deserialize.rs:43

--- failure trait_no_longer_object_safe: trait no longer object safe ---

Description:
Trait is no longer object safe, which breaks `dyn Trait` usage.
        ref: https://doc.rust-lang.org/stable/reference/items/traits.html#object-safety
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/trait_no_longer_object_safe.ron

Failed in:
  trait IntoStatic in file /tmp/.tmpThbCt0/merde/merde_core/src/into_static.rs:14

--- failure trait_removed_associated_type: trait's associated type was removed ---

Description:
A public trait's associated type was removed or renamed.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/trait_removed_associated_type.ron

Failed in:
  associated type Serializer::Error, previously at /tmp/.tmp1jLhqH/merde_core/src/serialize.rs:8
  associated type Deserializer::Error, previously at /tmp/.tmp1jLhqH/merde_core/src/deserialize.rs:15
```

### ⚠️ `merde_json` breaking changes

```
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/enum_missing.ron

Failed in:
  enum merde_json::MerdeJsonError, previously in file /tmp/.tmp1jLhqH/merde_json/src/lib.rs:244

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/module_missing.ron

Failed in:
  mod merde_json::tokio_io, previously in file /tmp/.tmp1jLhqH/merde_json/src/lib.rs:42

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/struct_missing.ron

Failed in:
  struct merde_json::tokio_io::AsyncWriteWrapper, previously in file /tmp/.tmp1jLhqH/merde_json/src/lib.rs:50

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/trait_missing.ron

Failed in:
  trait merde_json::JsonSerialize, previously in file /tmp/.tmp1jLhqH/merde_json/src/lib.rs:221
```

### ⚠️ `merde_msgpack` breaking changes

```
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/enum_missing.ron

Failed in:
  enum merde_msgpack::MsgpackError, previously in file /tmp/.tmp1jLhqH/merde_msgpack/src/lib.rs:42
```

### ⚠️ `merde_yaml` breaking changes

```
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/enum_missing.ron

Failed in:
  enum merde_yaml::MerdeYamlError, previously in file /tmp/.tmp1jLhqH/merde_yaml/src/lib.rs:26
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `merde`
<blockquote>

## [8.1.4](https://github.com/bearcove/merde/compare/merde-v8.1.3...merde-v8.1.4) - 2024-11-30

### Other

- remove async versions of things
- wip dyn serialize
- Tests pass
- no errors left?
- Fix more warnings and errors
- More!
- yay other errors
- Dwip
- Remove JsonSerialize trait
- Expose an async Deserializer interface
- Make Deserializer::next async
- Move things around re: absorbing merde_time in merde_core
- Yus
</blockquote>

## `merde_core`
<blockquote>

## [9.0.0](https://github.com/bearcove/merde/compare/merde_core-v8.1.1...merde_core-v9.0.0) - 2024-11-30

### Other

- Introduce DynDeserialize
- Remove workaround for https://github.com/rust-lang/rust/issues/133676
- Mhh
- Use DynSerialize in merde_json
- Introduce DynSerialize
- Rename serialize_sync to serialize
- remove async versions of things
- wip dyn serialize
- More!
- yay other errors
- Dwip
- lift static requirement
- mhh lifetimes yes
- mh
- well that's hard
- Expose to_tokio_writer
- Remove JsonSerialize trait
- Expose an async Deserializer interface
- Make Deserializer::next async
- Move things around re: absorbing merde_time in merde_core
- Yus
</blockquote>

## `merde_json`
<blockquote>

## [9.0.0](https://github.com/bearcove/merde/compare/merde_json-v8.0.2...merde_json-v9.0.0) - 2024-11-30

### Other

- Mhh
- Use DynSerialize in merde_json
- Rename serialize_sync to serialize
- async stuff Does Not Work for now
- remove async versions of things
- wip dyn serialize
- bye bigint
- Remove unused jiter_lite methods
- Fix more warnings and errors
- More!
- yay other errors
- Dwip
- Expose to_tokio_writer
- Remove JsonSerialize trait
- Expose an async Deserializer interface
- Make Deserializer::next async
- Move things around re: absorbing merde_time in merde_core
</blockquote>

## `merde_msgpack`
<blockquote>

## [9.0.0](https://github.com/bearcove/merde/compare/merde_msgpack-v8.0.2...merde_msgpack-v9.0.0) - 2024-11-30

### Other

- remove async versions of things
- More!
- yay other errors
- Expose an async Deserializer interface
- Make Deserializer::next async
</blockquote>

## `merde_yaml`
<blockquote>

## [9.0.0](https://github.com/bearcove/merde/compare/merde_yaml-v8.0.2...merde_yaml-v9.0.0) - 2024-11-30

### Other

- remove async versions of things
- More!
- yay other errors
- Expose an async Deserializer interface
- Make Deserializer::next async
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).