### PR TITLE
chore: release v10.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -317,7 +317,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "merde"
-version = "9.0.1"
+version = "10.0.0"
 dependencies = [
  "ahash",
  "merde_core",
@@ -328,7 +328,7 @@ dependencies = [
 
 [[package]]
 name = "merde_core"
-version = "9.0.1"
+version = "10.0.0"
 dependencies = [
  "compact_bytes",
  "compact_str",
@@ -342,7 +342,7 @@ dependencies = [
 
 [[package]]
 name = "merde_json"
-version = "9.0.1"
+version = "10.0.0"
 dependencies = [
  "itoa",
  "lexical-parse-float",
@@ -361,7 +361,7 @@ dependencies = [
 
 [[package]]
 name = "merde_msgpack"
-version = "9.0.1"
+version = "10.0.0"
 dependencies = [
  "merde_core",
  "merde_loggingserializer",
@@ -370,7 +370,7 @@ dependencies = [
 
 [[package]]
 name = "merde_yaml"
-version = "9.0.1"
+version = "10.0.0"
 dependencies = [
  "merde_core",
  "yaml-rust2",

--- a/merde/CHANGELOG.md
+++ b/merde/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [10.0.0](https://github.com/bearcove/merde/compare/merde-v9.0.1...merde-v10.0.0) - 2024-12-04
+
+### Other
+
+- [**breaking**] Force a major version bump
+
 ## [9.0.1](https://github.com/bearcove/merde/compare/merde-v9.0.0...merde-v9.0.1) - 2024-12-02
 
 ### Other

--- a/merde/Cargo.toml
+++ b/merde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "merde"
-version = "9.0.1"
+version = "10.0.0"
 edition = "2021"
 authors = ["Amos Wenger <amos@bearcove.net>"]
 description = "Serialize and deserialize with declarative macros"
@@ -56,10 +56,10 @@ path = "examples/opinions.rs"
 required-features = ["json"]
 
 [dependencies]
-merde_core = { version = "9.0.1", path = "../merde_core", optional = true }
-merde_json = { version = "9.0.1", path = "../merde_json", optional = true }
-merde_yaml = { version = "9.0.1", path = "../merde_yaml", optional = true }
-merde_msgpack = { version = "9.0.1", path = "../merde_msgpack", optional = true }
+merde_core = { version = "10.0.0", path = "../merde_core", optional = true }
+merde_json = { version = "10.0.0", path = "../merde_json", optional = true }
+merde_yaml = { version = "10.0.0", path = "../merde_yaml", optional = true }
+merde_msgpack = { version = "10.0.0", path = "../merde_msgpack", optional = true }
 ahash = { version = "0.8.11", optional = true }
 
 [features]

--- a/merde_core/CHANGELOG.md
+++ b/merde_core/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [10.0.0](https://github.com/bearcove/merde/compare/merde_core-v9.0.1...merde_core-v10.0.0) - 2024-12-04
+
+### Other
+
+- [**breaking**] Force a major version bump
+- remove rubicon (merde has a single ABI now anyway)
+
 ## [9.0.1](https://github.com/bearcove/merde/compare/merde_core-v9.0.0...merde_core-v9.0.1) - 2024-12-02
 
 ### Other

--- a/merde_core/Cargo.toml
+++ b/merde_core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "merde_core"
-version = "9.0.1"
+version = "10.0.0"
 authors = ["Amos Wenger <amos@bearcove.net>"]
 description = "Base types for merde"
 license = "Apache-2.0 OR MIT"

--- a/merde_json/CHANGELOG.md
+++ b/merde_json/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [10.0.0](https://github.com/bearcove/merde/compare/merde_json-v9.0.1...merde_json-v10.0.0) - 2024-12-04
+
+### Other
+
+- [**breaking**] Force a major version bump
+
 ## [9.0.1](https://github.com/bearcove/merde/compare/merde_json-v9.0.0...merde_json-v9.0.1) - 2024-12-02
 
 ### Other

--- a/merde_json/Cargo.toml
+++ b/merde_json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "merde_json"
-version = "9.0.1"
+version = "10.0.0"
 edition = "2021"
 authors = ["Amos Wenger <amos@bearcove.net>"]
 description = "JSON serialization and deserialization for merde, via jiter"
@@ -13,7 +13,7 @@ categories = ["encoding", "parser-implementations"]
 [dependencies]
 itoa = "1.0.11"
 lexical-parse-float = { version = "0.8.5", features = ["format"] }
-merde_core = { version = "9.0.1", path = "../merde_core" }
+merde_core = { version = "10.0.0", path = "../merde_core" }
 ryu = "1.0.18"
 tokio = { version = "1", optional = true, features = ["io-util"] }
 

--- a/merde_loggingserializer/Cargo.toml
+++ b/merde_loggingserializer/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 publish = false
 
 [dependencies]
-merde_core = { version = "9.0.1", path = "../merde_core" }
+merde_core = { version = "10.0.0", path = "../merde_core" }
 

--- a/merde_msgpack/CHANGELOG.md
+++ b/merde_msgpack/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [10.0.0](https://github.com/bearcove/merde/compare/merde_msgpack-v9.0.1...merde_msgpack-v10.0.0) - 2024-12-04
+
+### Other
+
+- [**breaking**] Force a major version bump
+
 ## [9.0.1](https://github.com/bearcove/merde/compare/merde_msgpack-v9.0.0...merde_msgpack-v9.0.1) - 2024-12-02
 
 ### Other

--- a/merde_msgpack/Cargo.toml
+++ b/merde_msgpack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "merde_msgpack"
-version = "9.0.1"
+version = "10.0.0"
 edition = "2021"
 authors = ["Amos Wenger <amos@bearcove.net>"]
 description = "msgpack serizliation/deserialization for merde"
@@ -11,7 +11,7 @@ keywords = ["msgpack", "messagepack", "serialization", "deserialization"]
 categories = ["encoding", "parser-implementations"]
 
 [dependencies]
-merde_core = { version = "9.0.1", path = "../merde_core" }
+merde_core = { version = "10.0.0", path = "../merde_core" }
 rmp = "0.8.14"
 
 [dev-dependencies]

--- a/merde_yaml/CHANGELOG.md
+++ b/merde_yaml/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [10.0.0](https://github.com/bearcove/merde/compare/merde_yaml-v9.0.1...merde_yaml-v10.0.0) - 2024-12-04
+
+### Other
+
+- [**breaking**] Force a major version bump
+
 ## [9.0.1](https://github.com/bearcove/merde/compare/merde_yaml-v9.0.0...merde_yaml-v9.0.1) - 2024-12-02
 
 ### Other

--- a/merde_yaml/Cargo.toml
+++ b/merde_yaml/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "merde_yaml"
-version = "9.0.1"
+version = "10.0.0"
 edition = "2021"
 authors = ["Amos Wenger <amos@bearcove.net>"]
 description = "YAML deserialization for merde"
@@ -11,6 +11,6 @@ keywords = ["yaml", "serialization", "deserialization"]
 categories = ["encoding", "parser-implementations"]
 
 [dependencies]
-merde_core = { version = "9.0.1", path = "../merde_core" }
+merde_core = { version = "10.0.0", path = "../merde_core" }
 yaml-rust2 = { version = "0.8.1", default-features = false }
 


### PR DESCRIPTION
## 🤖 New release
* `merde`: 9.0.1 -> 10.0.0 (✓ API compatible changes)
* `merde_core`: 9.0.1 -> 10.0.0 (⚠️ API breaking changes)
* `merde_json`: 9.0.1 -> 10.0.0 (✓ API compatible changes)
* `merde_msgpack`: 9.0.1 -> 10.0.0 (✓ API compatible changes)
* `merde_yaml`: 9.0.1 -> 10.0.0 (✓ API compatible changes)

### ⚠️ `merde_core` breaking changes

```
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/function_missing.ron

Failed in:
  function merde_core::compatibility_check_once, previously in file /tmp/.tmpjyw7R5/merde_core/src/lib.rs:58
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `merde`
<blockquote>

## [10.0.0](https://github.com/bearcove/merde/compare/merde-v9.0.1...merde-v10.0.0) - 2024-12-04

### Other

- [**breaking**] Force a major version bump
</blockquote>

## `merde_core`
<blockquote>

## [10.0.0](https://github.com/bearcove/merde/compare/merde_core-v9.0.1...merde_core-v10.0.0) - 2024-12-04

### Other

- [**breaking**] Force a major version bump
- remove rubicon (merde has a single ABI now anyway)
</blockquote>

## `merde_json`
<blockquote>

## [10.0.0](https://github.com/bearcove/merde/compare/merde_json-v9.0.1...merde_json-v10.0.0) - 2024-12-04

### Other

- [**breaking**] Force a major version bump
</blockquote>

## `merde_msgpack`
<blockquote>

## [10.0.0](https://github.com/bearcove/merde/compare/merde_msgpack-v9.0.1...merde_msgpack-v10.0.0) - 2024-12-04

### Other

- [**breaking**] Force a major version bump
</blockquote>

## `merde_yaml`
<blockquote>

## [10.0.0](https://github.com/bearcove/merde/compare/merde_yaml-v9.0.1...merde_yaml-v10.0.0) - 2024-12-04

### Other

- [**breaking**] Force a major version bump
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).