### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,7 +323,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "merde"
-version = "10.0.6"
+version = "10.0.7"
 dependencies = [
  "ahash",
  "merde_core",
@@ -334,7 +334,7 @@ dependencies = [
 
 [[package]]
 name = "merde_core"
-version = "10.0.5"
+version = "10.0.6"
 dependencies = [
  "camino",
  "compact_bytes",
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "merde_json"
-version = "10.0.5"
+version = "10.0.6"
 dependencies = [
  "itoa",
  "lexical-parse-float",
@@ -368,7 +368,7 @@ dependencies = [
 
 [[package]]
 name = "merde_msgpack"
-version = "10.0.5"
+version = "10.0.6"
 dependencies = [
  "merde_core",
  "merde_loggingserializer",
@@ -377,7 +377,7 @@ dependencies = [
 
 [[package]]
 name = "merde_yaml"
-version = "10.0.5"
+version = "10.0.6"
 dependencies = [
  "merde_core",
  "yaml-rust2",

--- a/merde/CHANGELOG.md
+++ b/merde/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [10.0.7](https://github.com/bearcove/merde/compare/merde-v10.0.6...merde-v10.0.7) - 2025-04-25
+
+### Other
+
+- updated the following local packages: merde_core, merde_json, merde_msgpack, merde_yaml
+
 ## [10.0.6](https://github.com/bearcove/merde/compare/merde-v10.0.5...merde-v10.0.6) - 2025-04-16
 
 ### Other

--- a/merde/Cargo.toml
+++ b/merde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "merde"
-version = "10.0.6"
+version = "10.0.7"
 edition = "2021"
 authors = ["Amos Wenger <amos@bearcove.net>"]
 description = "Serialize and deserialize with declarative macros"
@@ -61,10 +61,10 @@ path = "examples/mousedown.rs"
 required-features = ["json"]
 
 [dependencies]
-merde_core = { version = "10.0.5", path = "../merde_core", optional = true }
-merde_json = { version = "10.0.5", path = "../merde_json", optional = true }
-merde_yaml = { version = "10.0.5", path = "../merde_yaml", optional = true }
-merde_msgpack = { version = "10.0.5", path = "../merde_msgpack", optional = true }
+merde_core = { version = "10.0.6", path = "../merde_core", optional = true }
+merde_json = { version = "10.0.6", path = "../merde_json", optional = true }
+merde_yaml = { version = "10.0.6", path = "../merde_yaml", optional = true }
+merde_msgpack = { version = "10.0.6", path = "../merde_msgpack", optional = true }
 ahash = { version = "0.8.11", optional = true }
 
 [features]

--- a/merde_core/CHANGELOG.md
+++ b/merde_core/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [10.0.6](https://github.com/bearcove/merde/compare/merde_core-v10.0.5...merde_core-v10.0.6) - 2025-04-25
+
+### Other
+
+- Update ordered-float to v5.0.0
+
 ## [10.0.5](https://github.com/bearcove/merde/compare/merde_core-v10.0.4...merde_core-v10.0.5) - 2025-04-16
 
 ### Other

--- a/merde_core/Cargo.toml
+++ b/merde_core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "merde_core"
-version = "10.0.5"
+version = "10.0.6"
 authors = ["Amos Wenger <amos@bearcove.net>"]
 description = "Base types for merde"
 license = "Apache-2.0 OR MIT"

--- a/merde_json/CHANGELOG.md
+++ b/merde_json/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [10.0.6](https://github.com/bearcove/merde/compare/merde_json-v10.0.5...merde_json-v10.0.6) - 2025-04-25
+
+### Other
+
+- updated the following local packages: merde_core
+
 ## [10.0.5](https://github.com/bearcove/merde/compare/merde_json-v10.0.4...merde_json-v10.0.5) - 2025-04-16
 
 ### Other

--- a/merde_json/Cargo.toml
+++ b/merde_json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "merde_json"
-version = "10.0.5"
+version = "10.0.6"
 edition = "2021"
 authors = ["Amos Wenger <amos@bearcove.net>"]
 description = "JSON serialization and deserialization for merde, via jiter"
@@ -13,7 +13,7 @@ categories = ["encoding", "parser-implementations"]
 [dependencies]
 itoa = "1.0.11"
 lexical-parse-float = { version = "0.8.5", features = ["format"] }
-merde_core = { version = "10.0.5", path = "../merde_core" }
+merde_core = { version = "10.0.6", path = "../merde_core" }
 ryu = "1.0.18"
 tokio = { version = "1", optional = true, features = ["io-util"] }
 

--- a/merde_loggingserializer/Cargo.toml
+++ b/merde_loggingserializer/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 publish = false
 
 [dependencies]
-merde_core = { version = "10.0.5", path = "../merde_core" }
+merde_core = { version = "10.0.6", path = "../merde_core" }
 

--- a/merde_msgpack/CHANGELOG.md
+++ b/merde_msgpack/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [10.0.6](https://github.com/bearcove/merde/compare/merde_msgpack-v10.0.5...merde_msgpack-v10.0.6) - 2025-04-25
+
+### Other
+
+- updated the following local packages: merde_core
+
 ## [10.0.5](https://github.com/bearcove/merde/compare/merde_msgpack-v10.0.4...merde_msgpack-v10.0.5) - 2025-04-16
 
 ### Other

--- a/merde_msgpack/Cargo.toml
+++ b/merde_msgpack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "merde_msgpack"
-version = "10.0.5"
+version = "10.0.6"
 edition = "2021"
 authors = ["Amos Wenger <amos@bearcove.net>"]
 description = "msgpack serizliation/deserialization for merde"
@@ -11,7 +11,7 @@ keywords = ["msgpack", "messagepack", "serialization", "deserialization"]
 categories = ["encoding", "parser-implementations"]
 
 [dependencies]
-merde_core = { version = "10.0.5", path = "../merde_core" }
+merde_core = { version = "10.0.6", path = "../merde_core" }
 rmp = "0.8.14"
 
 [dev-dependencies]

--- a/merde_yaml/CHANGELOG.md
+++ b/merde_yaml/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [10.0.6](https://github.com/bearcove/merde/compare/merde_yaml-v10.0.5...merde_yaml-v10.0.6) - 2025-04-25
+
+### Other
+
+- updated the following local packages: merde_core
+
 ## [10.0.5](https://github.com/bearcove/merde/compare/merde_yaml-v10.0.4...merde_yaml-v10.0.5) - 2025-04-16
 
 ### Other

--- a/merde_yaml/Cargo.toml
+++ b/merde_yaml/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "merde_yaml"
-version = "10.0.5"
+version = "10.0.6"
 edition = "2021"
 authors = ["Amos Wenger <amos@bearcove.net>"]
 description = "YAML deserialization for merde"
@@ -11,6 +11,6 @@ keywords = ["yaml", "serialization", "deserialization"]
 categories = ["encoding", "parser-implementations"]
 
 [dependencies]
-merde_core = { version = "10.0.5", path = "../merde_core" }
+merde_core = { version = "10.0.6", path = "../merde_core" }
 yaml-rust2 = { version = "0.8.1", default-features = false }
 


### PR DESCRIPTION



## 🤖 New release

* `merde_core`: 10.0.5 -> 10.0.6 (✓ API compatible changes)
* `merde_json`: 10.0.5 -> 10.0.6
* `merde_msgpack`: 10.0.5 -> 10.0.6
* `merde_yaml`: 10.0.5 -> 10.0.6
* `merde`: 10.0.6 -> 10.0.7

<details><summary><i><b>Changelog</b></i></summary><p>

## `merde_core`

<blockquote>

## [10.0.6](https://github.com/bearcove/merde/compare/merde_core-v10.0.5...merde_core-v10.0.6) - 2025-04-25

### Other

- Upgrade rusqlite
- Update ordered-float to v5.0.0
</blockquote>

## `merde_json`

<blockquote>

## [10.0.6](https://github.com/bearcove/merde/compare/merde_json-v10.0.5...merde_json-v10.0.6) - 2025-04-25

### Other

- updated the following local packages: merde_core
</blockquote>

## `merde_msgpack`

<blockquote>

## [10.0.6](https://github.com/bearcove/merde/compare/merde_msgpack-v10.0.5...merde_msgpack-v10.0.6) - 2025-04-25

### Other

- updated the following local packages: merde_core
</blockquote>

## `merde_yaml`

<blockquote>

## [10.0.6](https://github.com/bearcove/merde/compare/merde_yaml-v10.0.5...merde_yaml-v10.0.6) - 2025-04-25

### Other

- updated the following local packages: merde_core
</blockquote>

## `merde`

<blockquote>

## [10.0.7](https://github.com/bearcove/merde/compare/merde-v10.0.6...merde-v10.0.7) - 2025-04-25

### Other

- updated the following local packages: merde_core, merde_json, merde_msgpack, merde_yaml
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).