### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "merde"
-version = "10.0.7"
+version = "10.0.8"
 dependencies = [
  "ahash",
  "merde_core",
@@ -353,7 +353,7 @@ dependencies = [
 
 [[package]]
 name = "merde_json"
-version = "10.0.6"
+version = "10.0.7"
 dependencies = [
  "itoa",
  "lexical-parse-float",

--- a/merde/CHANGELOG.md
+++ b/merde/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [10.0.8](https://github.com/bearcove/merde/compare/merde-v10.0.7...merde-v10.0.8) - 2025-06-03
+
+### Other
+
+- Update README.md
+
 ## [10.0.7](https://github.com/bearcove/merde/compare/merde-v10.0.6...merde-v10.0.7) - 2025-04-25
 
 ### Other

--- a/merde/Cargo.toml
+++ b/merde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "merde"
-version = "10.0.7"
+version = "10.0.8"
 edition = "2021"
 authors = ["Amos Wenger <amos@bearcove.net>"]
 description = "Serialize and deserialize with declarative macros"
@@ -62,7 +62,7 @@ required-features = ["json"]
 
 [dependencies]
 merde_core = { version = "10.0.6", path = "../merde_core", optional = true }
-merde_json = { version = "10.0.6", path = "../merde_json", optional = true }
+merde_json = { version = "10.0.7", path = "../merde_json", optional = true }
 merde_yaml = { version = "10.0.6", path = "../merde_yaml", optional = true }
 merde_msgpack = { version = "10.0.6", path = "../merde_msgpack", optional = true }
 ahash = { version = "0.8.11", optional = true }

--- a/merde_json/CHANGELOG.md
+++ b/merde_json/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [10.0.7](https://github.com/bearcove/merde/compare/merde_json-v10.0.6...merde_json-v10.0.7) - 2025-06-03
+
+### Other
+
+- Update README.md
+
 ## [10.0.6](https://github.com/bearcove/merde/compare/merde_json-v10.0.5...merde_json-v10.0.6) - 2025-04-25
 
 ### Other

--- a/merde_json/Cargo.toml
+++ b/merde_json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "merde_json"
-version = "10.0.6"
+version = "10.0.7"
 edition = "2021"
 authors = ["Amos Wenger <amos@bearcove.net>"]
 description = "JSON serialization and deserialization for merde, via jiter"


### PR DESCRIPTION



## 🤖 New release

* `merde_json`: 10.0.6 -> 10.0.7 (✓ API compatible changes)
* `merde`: 10.0.7 -> 10.0.8 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `merde_json`

<blockquote>

## [10.0.7](https://github.com/bearcove/merde/compare/merde_json-v10.0.6...merde_json-v10.0.7) - 2025-06-03

### Other

- Update README.md
</blockquote>

## `merde`

<blockquote>

## [10.0.8](https://github.com/bearcove/merde/compare/merde-v10.0.7...merde-v10.0.8) - 2025-06-03

### Other

- Update README.md
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).