### PR TITLE
fix: deserializing unknown field values.

### DIFF
--- a/merde/CHANGELOG.md
+++ b/merde/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- deserializing unknown field values
+
 ## [10.0.7](https://github.com/bearcove/merde/compare/merde-v10.0.6...merde-v10.0.7) - 2025-04-25
 
 ### Other

--- a/merde/examples/opinions.rs
+++ b/merde/examples/opinions.rs
@@ -16,7 +16,7 @@ fn main() {
     eprintln!("{o:#?}");
 
     let input_too_many_fields = r#"
-        { "foo_bar": "hello", "foo_bar2": "world" }
+        { "foo_bar": "hello", "foo_bar2": {"cruel": "world"} }
     "#;
     assert!(merde_json::from_str::<Owned>(input_too_many_fields).is_err());
     let o: OwnedRelaxed = merde_json::from_str(input_too_many_fields).unwrap();

--- a/merde/src/lib.rs
+++ b/merde/src/lib.rs
@@ -73,6 +73,7 @@ macro_rules! impl_deserialize {
                                     if __opinions.deny_unknown_fields() {
                                         return Err($crate::MerdeError::UnknownProperty(__key).into());
                                     }
+                                    $crate::Value::deserialize(__de).await?;
                                 }
                             }
                         }
@@ -134,6 +135,7 @@ macro_rules! impl_deserialize {
                                     if __opinions.deny_unknown_fields() {
                                         return Err($crate::MerdeError::UnknownProperty(__key).into());
                                     }
+                                    $crate::Value::deserialize(__de).await?;
                                 }
                             }
                         }


### PR DESCRIPTION
Stop deserialization from choking on an unknown field with non-string values with `UnexpectedEvent { got: MapStart, expected: [Str, MapEnd], help: Some("While deserializing WhateverStruct") }`.

If you wanted it to do less work with more code, we could make it use a hacked-down version of `merde::Value::deserialize` of the form

- ArrayStart => return when #(ArrayStart) - #(ArrayEnd) is zero
- MapStart => return when #(MapStart) - #(MapEnd) is zero
- _ => return

buuuuuuut I don't know if you'd rather have such a SkippedUnknownFieldValue struct live in merde_core or inline it here in the 2 places we need it or dedup those into a `#[doc(hidden)]` macro.